### PR TITLE
Releng changes for jdtls

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,8 +45,19 @@ pipeline {
 				always {
 					archiveArtifacts artifacts: '*.log,*/target/work/data/.metadata/*.log,*/tests/target/work/data/.metadata/*.log,apiAnalyzer-workspace/.metadata/*.log', allowEmptyArchive: true
 					junit '**/target/surefire-reports/*.xml'
-					discoverGitReferenceBuild referenceJob: 'eclipse.jdt.core-github/master'
 					recordIssues publishAllIssues: true, tools: [java(), mavenConsole(), javaDoc()]
+				}
+			}
+		}
+		stage('Deploy') {
+			when {
+				branch 'master'
+			}
+			steps {
+				sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
+					sh 'ssh genie.ls@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/jdtls/jdt-core-incubator/snapshots'
+					sh 'ssh genie.ls@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/jdtls/jdt-core-incubator/snapshots'
+					sh 'scp -r repository/target/repository/* genie.ls@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/jdtls/jdt-core-incubator/snapshots'
 				}
 			}
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <module>org.eclipse.jdt.apt.pluggable.tests</module>
     <module>org.eclipse.jdt.apt.tests</module>
     <module>org.eclipse.jdt.compiler.apt.tests</module>
+    <module>repository</module>
   </modules>
   
   <build>

--- a/repository/category.xml
+++ b/repository/category.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <bundle id="org.eclipse.jdt.core.compiler.batch"/>
+   <bundle id="org.eclipse.jdt.core"/>
+   <bundle id="org.eclipse.jdt.apt.core"/>
+</site>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Copyright (c) 2023 Red Hat Inc. and others
+	All rights reserved. This program and the accompanying materials
+	are made available under the terms of the Eclipse Public License 2.0
+	which accompanies this distribution, and is available at
+	https://www.eclipse.org/legal/epl-2.0/
+
+	SPDX-License-Identifier: EPL-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>eclipse.jdt.core</artifactId>
+    <groupId>org.eclipse.jdt</groupId>
+    <version>4.31.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>org.eclipse.jdt.core.repository</artifactId>
+  <packaging>eclipse-repository</packaging>
+</project>


### PR DESCRIPTION
* Fix build due to missing jenkins plugin in jdt.ls JIPP
* Add repository module and publish 3 bundles used by jdt.ls into it
* Publish build to download.eclipse.org/jdtls/jdt-core-incubator/snapshots