### PR TITLE
Fix `CompilationUnitTests.testDefaultValue*()` and some of `CompilationUnitTests.testDeprecatedFlag*()`

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
@@ -524,6 +524,10 @@ class DOMToModelPopulator extends ASTVisitor {
 			return new SimpleEntry<>(value, type);
 		}
 		if (dom instanceof PrefixExpression prefixExpression) {
+			Expression operand = prefixExpression.getOperand();
+			if (!(operand instanceof NumberLiteral) && !(operand instanceof BooleanLiteral)) {
+				return new SimpleEntry<>(null, IMemberValuePair.K_UNKNOWN);
+			}
 			Entry<Object, Integer> entry = memberValue(prefixExpression.getOperand());
 			return new SimpleEntry<>(prefixExpression.getOperator().toString() + entry.getKey(), entry.getValue());
 		}


### PR DESCRIPTION
- Use modifiers instead of flags to populate `MemberElementInfo.flags` (the field and setter are misnamed, it contains the modifiers)
- Call code that searches for `@Deprecated` annotation on all body declarations
- Cache calls to check for an imported class called `Deprecated` so that it doesn't happen multiple times