### PR TITLE
Fixes to `DOMToModelPopulator` to address test failures in `CompilationUnitTests`

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
@@ -178,7 +178,11 @@ protected boolean buildStructure(OpenableElementInfo info, final IProgressMonito
 			newAST.accept(new DOMToModelPopulator(newElements, this, unitInfo));
 			// unitInfo.setModule();
 			// unitInfo.setSourceLength(newSourceLength);
-			unitInfo.setIsStructureKnown(true);
+			boolean structureKnown = true;
+			for (IProblem problem : newAST.getProblems()) {
+				structureKnown &= (IProblem.Syntax & problem.getID()) == 0;
+			}
+			unitInfo.setIsStructureKnown(structureKnown);
 		}
 	} else {
 		CompilationUnitStructureRequestor requestor = new CompilationUnitStructureRequestor(this, unitInfo, newElements);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
@@ -48,6 +48,7 @@ import org.eclipse.jdt.core.dom.MemberValuePair;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.ModuleDeclaration;
 import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.AbstractTagElement;
 import org.eclipse.jdt.core.dom.NormalAnnotation;
 import org.eclipse.jdt.core.dom.NullLiteral;
 import org.eclipse.jdt.core.dom.NumberLiteral;
@@ -63,6 +64,7 @@ import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TagElement;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.TypeLiteral;
 import org.eclipse.jdt.core.dom.UsesDirective;
@@ -763,6 +765,15 @@ class DOMToModelPopulator extends ASTVisitor {
 		return res;
 	}
 	private boolean isNodeDeprecated(BodyDeclaration node) {
+		if (node.getJavadoc() != null) {
+			boolean javadocDeprecated = node.getJavadoc().tags().stream() //
+					.anyMatch(tag -> {
+						return TagElement.TAG_DEPRECATED.equals(((AbstractTagElement)tag).getTagName());
+					});
+			if (javadocDeprecated) {
+				return true;
+			}
+		}
 		return ((List<ASTNode>)node.modifiers()).stream() //
 				.anyMatch(modifier -> {
 					if (!isAnnotation(modifier)) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
@@ -36,6 +36,7 @@ import org.eclipse.jdt.core.dom.ArrayInitializer;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.BooleanLiteral;
 import org.eclipse.jdt.core.dom.CharacterLiteral;
+import org.eclipse.jdt.core.dom.EnumConstantDeclaration;
 import org.eclipse.jdt.core.dom.EnumDeclaration;
 import org.eclipse.jdt.core.dom.ExportsDirective;
 import org.eclipse.jdt.core.dom.Expression;
@@ -273,27 +274,28 @@ class DOMToModelPopulator extends ASTVisitor {
 		this.infos.pop();
 	}
 
-//	@Override
-//	public boolean visit(EnumConstantDeclaration node) {
-//		SourceField newElement = new SourceField(this.elements.peek(), node.getName().toString());
-//		this.elements.push(newElement);
-//		addAsChild(this.infos.peek(), newElement);
-//		SourceFieldElementInfo info = new SourceFieldElementInfo();
-//		info.setSourceRangeStart(node.getStartPosition());
-//		info.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
-//		info.setFlags(node.getFlags());
-//		info.setNameSourceStart(node.getName().getStartPosition());
-//		info.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
-//		// TODO populate info
-//		this.infos.push(info);
-//		this.toPopulate.put(newElement, info);
-//		return true;
-//	}
-//	@Override
-//	public void endVisit(EnumConstantDeclaration decl) {
-//		this.elements.pop();
-//		this.infos.pop();
-//	}
+	@Override
+	public boolean visit(EnumConstantDeclaration node) {
+		SourceField newElement = new SourceField(this.elements.peek(), node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceFieldElementInfo info = new SourceFieldElementInfo();
+		info.setSourceRangeStart(node.getStartPosition());
+		info.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		boolean isDeprecated = isNodeDeprecated(node);
+		info.setFlags(node.getModifiers() | ClassFileConstants.AccEnum | (isDeprecated ? ClassFileConstants.AccDeprecated : 0));
+		info.setNameSourceStart(node.getName().getStartPosition());
+		info.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		// TODO populate info
+		this.infos.push(info);
+		this.toPopulate.put(newElement, info);
+		return true;
+	}
+	@Override
+	public void endVisit(EnumConstantDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
 
 	@Override
 	public boolean visit(RecordDeclaration node) {


### PR DESCRIPTION
- Fix `CompilationUnitTests.testIsEnumConstant1()`
- Fix `CompilationUnitTests.testGetImports()`
- Fix `CompilationUnitTests.testStructureUnknownForCU()`
- Fix remaining `CompilationUnitTests.testDeprecatedFlag*()`
- Fix `CompilationUnitTests.testGetCategories*()`
- Fix `CompilationUnitTests.testGetChildrenForCategory02()`