### PR TITLE
Fix: CommentRecordParser may miss javadoc in declarationStart

### DIFF
--- a/.github/workflows/ci-dom-javac.yml
+++ b/.github/workflows/ci-dom-javac.yml
@@ -1,0 +1,53 @@
+name: Continuous Integration with DOM/Javac
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}-dom
+    cancel-in-progress: true
+
+on:
+  push:
+    branches: [ 'dom-based-operations', 'dom-with-javac' ]
+  pull_request:
+    branches: [ 'dom-based-operations', 'dom-with-javac' ]
+
+jobs:
+  build-dom-javac:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install xmllint
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt install -y libxml2-utils
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - name: Enable DOM-first and Javac
+      run: sed -i 's$</argLine>$ -DCompilationUnit.DOM_BASED_OPERATIONS=true -DSourceIndexer.DOM_BASED_INDEXER=false -DICompilationUnitResolver=org.eclipse.jdt.core.dom.JavacCompilationUnitResolver -DAbstractImageBuilder.compiler=org.eclipse.jdt.internal.javac.JavacCompiler_</argLine>$g' */pom.xml
+    - name: Set up JDKs ☕
+      uses: actions/setup-java@v3
+      with:
+        java-version: |
+          8
+          17
+          20
+        mvn-toolchain-id: |
+          JavaSE-1.8
+          JavaSE-17
+          JavaSE-20
+        distribution: 'temurin'
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+      with:
+        maven-version: 3.9.3
+    - name: Build with Maven 🏗️
+      run: |
+        mvn clean install --batch-mode -f org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99
+        mvn -U clean verify --batch-mode --fail-at-end -Ptest-on-javase-20 -Pbree-libs -Papi-check -Djava.io.tmpdir=$WORKSPACE/tmp -Dproject.build.sourceEncoding=UTF-8 -Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17,20 -Djdt.performance.asserts=disabled" -Dcbi-ecj-version=99.99
+    - name: Test Report
+      if: success() || failure()    # run this step even if previous step failed
+      run: |
+        echo ▶️ TESTS RUN: $(xmllint --xpath 'string(/testsuite/@tests)' */target/surefire-reports/TEST-*.xml | awk '{n += $1}; END{print n}' -)
+        echo ❌ FAILURES: $(xmllint --xpath 'string(/testsuite/@failures)' */target/surefire-reports/TEST-*.xml | awk '{n += $1}; END{print n}' -)
+        echo 💥 ERRORS: $(xmllint --xpath 'string(/testsuite/@errors)' */target/surefire-reports/TEST-*.xml | awk '{n += $1}; END{print n}' -)
+        echo 🛑 SKIPPED: $(xmllint --xpath 'string(/testsuite/@skipped)' */target/surefire-reports/TEST-*.xml | awk '{n += $1}; END{print n}' -)

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
@@ -27,6 +27,7 @@ import junit.framework.Test;
 
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.BindingKey;
 import org.eclipse.jdt.core.IAnnotation;
@@ -7866,13 +7867,13 @@ public class ASTConverter15Test extends ConverterTestSetup {
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=173338
 	 */
 	public void test0238_2() throws JavaModelException {
-		this.workingCopy = getWorkingCopy("/Converter15/src/test0238/X.java", true/*resolve*/);
-		String contents =
-			"package test0238;\n" +
-			"public class X extends A {\n" +
-			"}";
+		this.workingCopy = getWorkingCopy("/Converter15/src/test0238/X.java",
+			"""
+			package test0238;
+			public class X extends A {
+			}""", true/*resolve*/);
 		ASTNode node = buildAST(
-				contents,
+				this.workingCopy.getSource(),
 				this.workingCopy,
 				false,
 				false,
@@ -7888,6 +7889,29 @@ public class ASTConverter15Test extends ConverterTestSetup {
 		typeBinding = typeBinding.getSuperclass();
 		IMethodBinding[] methodBindings = typeBinding.getDeclaredMethods();
 		assertNotNull("No method bindings", methodBindings);
+		assertEquals("wrong size", 2, methodBindings.length);
+	}
+
+	/*
+	 * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1915
+	 */
+	public void test0238_ASTParser() throws JavaModelException, CoreException {
+		this.workingCopy = getWorkingCopy("/Converter15/src/test0238/X.java",
+			"""
+			package test0238;
+			public class X extends A {
+			}
+			""", true /*resolve*/);
+		ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
+		parser.setBindingsRecovery(true);
+		parser.setResolveBindings(true);
+		parser.setStatementsRecovery(true);
+		parser.setSource(this.workingCopy);
+		parser.setProject(JavaCore.create(ResourcesPlugin.getWorkspace().getRoot().getProject("Converter15")));
+		CompilationUnit unit = (CompilationUnit) parser.createAST(null);
+		TypeDeclaration typeDeclaration = (TypeDeclaration) unit.types().get(0);
+		ITypeBinding superTypeBinding = typeDeclaration.resolveBinding().getSuperclass();
+		IMethodBinding[] methodBindings = superTypeBinding.getDeclaredMethods();
 		assertEquals("wrong size", 2, methodBindings.length);
 	}
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -1261,6 +1261,9 @@ class CompilationUnitResolver extends Compiler {
 				if (unit == null) {
 					unit = this.unitsToProcess[0]; // fall back to old behavior
 				}
+				if (this.totalUnits == 1 && this.lookupEnvironment.unitBeingCompleted == null) {
+					this.lookupEnvironment.unitBeingCompleted = unit;
+				}
 			} else {
 				// initial type binding creation
 				this.lookupEnvironment.buildTypeBindings(unit, null /*no access restriction*/);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ASTHolderCUInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ASTHolderCUInfo.java
@@ -19,7 +19,7 @@ import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
 public class ASTHolderCUInfo extends CompilationUnitElementInfo {
-	int astLevel;
+	public int astLevel;
 	boolean resolveBindings;
 	int reconcileFlags;
 	Map<String, CategorizedProblem[]> problems = null;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
@@ -19,11 +19,27 @@ package org.eclipse.jdt.internal.core;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.compiler.*;
 import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.MethodReference;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.ParameterizedType;
+import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.VariableDeclaration;
 import org.eclipse.jdt.internal.compiler.IProblemFactory;
 import org.eclipse.jdt.internal.compiler.SourceElementParser;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
@@ -46,10 +62,22 @@ import org.eclipse.text.edits.UndoEdit;
  * @see ICompilationUnit
  */
 public class CompilationUnit extends Openable implements ICompilationUnit, org.eclipse.jdt.internal.compiler.env.ICompilationUnit, SuffixConstants {
+	/**
+	 * Internal synonym for deprecated constant AST.JSL2
+	 * to alleviate deprecation warnings.
+	 * @deprecated
+	 */
+	/*package*/ static final int JLS2_INTERNAL = AST.JLS2;
+
+	public static boolean DOM_BASED_OPERATIONS = Boolean.getBoolean(CompilationUnit.class.getSimpleName() + ".DOM_BASED_OPERATIONS"); //$NON-NLS-1$
+	public static boolean DOM_BASED_COMPLETION = Boolean.getBoolean(CompilationUnit.class.getSimpleName() + ".codeComplete.DOM_BASED_OPERATIONS"); //$NON-NLS-1$
+
 	private static final IImportDeclaration[] NO_IMPORTS = new IImportDeclaration[0];
 
 	protected final String name;
 	public final WorkingCopyOwner owner;
+
+	private org.eclipse.jdt.core.dom.CompilationUnit ast;
 
 /**
  * Constructs a handle to a compilation unit with the given name in the
@@ -101,104 +129,132 @@ public void becomeWorkingCopy(IProgressMonitor monitor) throws JavaModelExceptio
 protected boolean buildStructure(OpenableElementInfo info, final IProgressMonitor pm, Map<IJavaElement, IElementInfo> newElements, IResource underlyingResource) throws JavaModelException {
 	CompilationUnitElementInfo unitInfo = (CompilationUnitElementInfo) info;
 
-	// ensure buffer is opened
-	IBuffer buffer = getBufferManager().getBuffer(CompilationUnit.this);
-	if (buffer == null) {
-		openBuffer(pm, unitInfo); // open buffer independently from the info, since we are building the info
-	}
-
 	// generate structure and compute syntax problems if needed
-	CompilationUnitStructureRequestor requestor = new CompilationUnitStructureRequestor(this, unitInfo, newElements);
 	JavaModelManager.PerWorkingCopyInfo perWorkingCopyInfo = getPerWorkingCopyInfo();
 	IJavaProject project = getJavaProject();
-
-	boolean createAST;
-	boolean resolveBindings;
-	int reconcileFlags;
-	Map<String, CategorizedProblem[]> problems;
-	if (info instanceof ASTHolderCUInfo) {
-		ASTHolderCUInfo astHolder = (ASTHolderCUInfo) info;
-		createAST = astHolder.astLevel != NO_AST;
-		resolveBindings = astHolder.resolveBindings;
-		reconcileFlags = astHolder.reconcileFlags;
-		problems = astHolder.problems;
-	} else {
-		createAST = false;
-		resolveBindings = false;
-		reconcileFlags = 0;
-		problems = null;
-	}
-
+	boolean createAST = info instanceof ASTHolderCUInfo astHolder ? astHolder.astLevel != NO_AST : false;
+	boolean resolveBindings = info instanceof ASTHolderCUInfo astHolder ? astHolder.resolveBindings : false;
+	int reconcileFlags = info instanceof ASTHolderCUInfo astHolder ? astHolder.reconcileFlags : 0;
 	boolean computeProblems = perWorkingCopyInfo != null && perWorkingCopyInfo.isActive() && project != null && JavaProject.hasJavaNature(project.getProject());
-	IProblemFactory problemFactory = new DefaultProblemFactory();
 	Map<String, String> options = this.getOptions(true);
 	if (!computeProblems) {
 		// disable task tags checking to speed up parsing
 		options.put(JavaCore.COMPILER_TASK_TAGS, ""); //$NON-NLS-1$
 	}
-	CompilerOptions compilerOptions = new CompilerOptions(options);
-	compilerOptions.ignoreMethodBodies = (reconcileFlags & ICompilationUnit.IGNORE_METHOD_BODIES) != 0;
-	SourceElementParser parser = new SourceElementParser(
-		requestor,
-		problemFactory,
-		compilerOptions,
-		true/*report local declarations*/,
-		!createAST /*optimize string literals only if not creating a DOM AST*/);
-	parser.reportOnlyOneSyntaxError = !computeProblems;
-	parser.setMethodsFullRecovery(true);
-	parser.setStatementsRecovery((reconcileFlags & ICompilationUnit.ENABLE_STATEMENTS_RECOVERY) != 0);
-
-	if (!computeProblems && !resolveBindings && !createAST) // disable javadoc parsing if not computing problems, not resolving and not creating ast
-		parser.javadocParser.checkDocComment = false;
-	requestor.parser = parser;
 
 	// update timestamp (might be IResource.NULL_STAMP if original does not exist)
 	if (underlyingResource == null) {
 		underlyingResource = getResource();
 	}
 	// underlying resource is null in the case of a working copy on a class file in a jar
-	if (underlyingResource != null)
+	if (underlyingResource != null) {
 		unitInfo.timestamp = ((IFile)underlyingResource).getModificationStamp();
+	}
 
-	// compute other problems if needed
-	CompilationUnitDeclaration compilationUnitDeclaration = null;
+	// ensure buffer is opened
+	IBuffer buffer = getBufferManager().getBuffer(CompilationUnit.this);
+	if (buffer == null) {
+		openBuffer(pm, unitInfo); // open buffer independently from the info, since we are building the info
+	}
+
 	CompilationUnit source = cloneCachingContents();
-	try {
-		if (computeProblems) {
-			if (problems == null) {
-				// report problems to the problem requestor
-				problems = new HashMap<>();
-				compilationUnitDeclaration = CompilationUnitProblemFinder.process(source, parser, this.owner, problems, createAST, reconcileFlags, pm);
-				try {
-					perWorkingCopyInfo.beginReporting();
-					for (Iterator<CategorizedProblem[]> iteraror = problems.values().iterator(); iteraror.hasNext();) {
-						CategorizedProblem[] categorizedProblems = iteraror.next();
-						if (categorizedProblems == null) continue;
-						for (int i = 0, length = categorizedProblems.length; i < length; i++) {
-							perWorkingCopyInfo.acceptProblem(categorizedProblems[i]);
+	Map<String, CategorizedProblem[]> problems = info instanceof ASTHolderCUInfo astHolder ? astHolder.problems : null;
+	if (DOM_BASED_OPERATIONS) {
+		ASTParser astParser = ASTParser.newParser(info instanceof ASTHolderCUInfo astHolder && astHolder.astLevel > 0 ? astHolder.astLevel : AST.getJLSLatest());
+		astParser.setWorkingCopyOwner(getOwner());
+		astParser.setSource(this instanceof ClassFileWorkingCopy ? source : this);
+		astParser.setProject(getJavaProject());
+		astParser.setStatementsRecovery((reconcileFlags & ICompilationUnit.ENABLE_STATEMENTS_RECOVERY) != 0);
+		astParser.setResolveBindings(computeProblems || resolveBindings);
+		astParser.setBindingsRecovery((reconcileFlags & ICompilationUnit.ENABLE_BINDINGS_RECOVERY) != 0);
+		astParser.setIgnoreMethodBodies((reconcileFlags & ICompilationUnit.IGNORE_METHOD_BODIES) != 0);
+		astParser.setCompilerOptions(options);
+		if (astParser.createAST(pm) instanceof org.eclipse.jdt.core.dom.CompilationUnit newAST) {
+			if (computeProblems) {
+				if (perWorkingCopyInfo != null && problems == null) {
+					try {
+						perWorkingCopyInfo.beginReporting();
+						for (IProblem problem : newAST.getProblems()) {
+							perWorkingCopyInfo.acceptProblem(problem);
 						}
+					} finally {
+						perWorkingCopyInfo.endReporting();
 					}
-				} finally {
-					perWorkingCopyInfo.endReporting();
+				} else if (newAST.getProblems().length > 0) {
+					problems.put(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, Stream.of(newAST.getProblems()).filter(CategorizedProblem.class::isInstance)
+						.map(CategorizedProblem.class::cast)
+						.toArray(CategorizedProblem[]::new));
+				}
+			}
+			if (info instanceof ASTHolderCUInfo astHolder) {
+				astHolder.ast = newAST;
+			}
+			newAST.accept(new DOMToModelPopulator(newElements, this, unitInfo));
+			// unitInfo.setModule();
+			// unitInfo.setSourceLength(newSourceLength);
+			boolean structureKnown = true;
+			for (IProblem problem : newAST.getProblems()) {
+				structureKnown &= (IProblem.Syntax & problem.getID()) == 0;
+			}
+			unitInfo.setIsStructureKnown(structureKnown);
+		}
+	} else {
+		CompilerOptions compilerOptions = new CompilerOptions(options);
+		compilerOptions.ignoreMethodBodies = (reconcileFlags & ICompilationUnit.IGNORE_METHOD_BODIES) != 0;
+		CompilationUnitStructureRequestor requestor = new CompilationUnitStructureRequestor(this, unitInfo, newElements);
+		IProblemFactory problemFactory = new DefaultProblemFactory();
+		SourceElementParser parser = new SourceElementParser(
+			requestor,
+			problemFactory,
+			compilerOptions,
+			true/*report local declarations*/,
+			!createAST /*optimize string literals only if not creating a DOM AST*/);
+		parser.reportOnlyOneSyntaxError = !computeProblems;
+		parser.setMethodsFullRecovery(true);
+		parser.setStatementsRecovery((reconcileFlags & ICompilationUnit.ENABLE_STATEMENTS_RECOVERY) != 0);
+
+		if (!computeProblems && !resolveBindings && !createAST) // disable javadoc parsing if not computing problems, not resolving and not creating ast
+			parser.javadocParser.checkDocComment = false;
+		requestor.parser = parser;
+
+		// compute other problems if needed
+		CompilationUnitDeclaration compilationUnitDeclaration = null;
+		try {
+			if (computeProblems) {
+				if (problems == null) {
+					// report problems to the problem requestor
+					problems = new HashMap<>();
+					compilationUnitDeclaration = CompilationUnitProblemFinder.process(source, parser, this.owner, problems, createAST, reconcileFlags, pm);
+					try {
+						perWorkingCopyInfo.beginReporting();
+						for (CategorizedProblem[] categorizedProblems : problems.values()) {
+							if (categorizedProblems == null) continue;
+							for (CategorizedProblem categorizedProblem : categorizedProblems) {
+								perWorkingCopyInfo.acceptProblem(categorizedProblem);
+							}
+						}
+					} finally {
+						perWorkingCopyInfo.endReporting();
+					}
+				} else {
+					// collect problems
+					compilationUnitDeclaration = CompilationUnitProblemFinder.process(source, parser, this.owner, problems, createAST, reconcileFlags, pm);
 				}
 			} else {
-				// collect problems
-				compilationUnitDeclaration = CompilationUnitProblemFinder.process(source, parser, this.owner, problems, createAST, reconcileFlags, pm);
+				compilationUnitDeclaration = parser.parseCompilationUnit(source, true /*full parse to find local elements*/, pm);
 			}
-		} else {
-			compilationUnitDeclaration = parser.parseCompilationUnit(source, true /*full parse to find local elements*/, pm);
-		}
 
-		if (createAST) {
-			int astLevel = ((ASTHolderCUInfo) info).astLevel;
-			org.eclipse.jdt.core.dom.CompilationUnit cu = AST.convertCompilationUnit(astLevel, compilationUnitDeclaration, options, computeProblems, source, reconcileFlags, pm);
-			((ASTHolderCUInfo) info).ast = cu;
+			if (createAST) {
+				int astLevel = ((ASTHolderCUInfo) info).astLevel;
+				org.eclipse.jdt.core.dom.CompilationUnit cu = AST.convertCompilationUnit(astLevel, compilationUnitDeclaration, options, computeProblems, source, reconcileFlags, pm);
+				((ASTHolderCUInfo) info).ast = cu;
+			}
+		} finally {
+		    if (compilationUnitDeclaration != null) {
+		    	unitInfo.hasFunctionalTypes = compilationUnitDeclaration.hasFunctionalTypes();
+		        compilationUnitDeclaration.cleanUp();
+		    }
 		}
-	} finally {
-	    if (compilationUnitDeclaration != null) {
-	    	unitInfo.hasFunctionalTypes = compilationUnitDeclaration.hasFunctionalTypes();
-	        compilationUnitDeclaration.cleanUp();
-	    }
 	}
 
 	return unitInfo.isStructureKnown();
@@ -357,6 +413,10 @@ public void codeComplete(int offset, CompletionRequestor requestor, WorkingCopyO
 
 @Override
 public void codeComplete(int offset, CompletionRequestor requestor, WorkingCopyOwner workingCopyOwner, IProgressMonitor monitor) throws JavaModelException {
+	if (DOM_BASED_COMPLETION) {
+		new DOMCompletionEngine(offset, getOrBuildAST(workingCopyOwner), requestor, monitor).run();
+		return;
+	}
 	codeComplete(
 			this,
 			isWorkingCopy() ? (org.eclipse.jdt.internal.compiler.env.ICompilationUnit) getOriginalElement() : this,
@@ -379,8 +439,93 @@ public IJavaElement[] codeSelect(int offset, int length) throws JavaModelExcepti
  */
 @Override
 public IJavaElement[] codeSelect(int offset, int length, WorkingCopyOwner workingCopyOwner) throws JavaModelException {
-	return super.codeSelect(this, offset, length, workingCopyOwner);
+	if (DOM_BASED_OPERATIONS) {
+		org.eclipse.jdt.core.dom.CompilationUnit currentAST = getOrBuildAST(workingCopyOwner);
+		if (currentAST == null) {
+			return new IJavaElement[0];
+		}
+		NodeFinder finder = new NodeFinder(currentAST, offset, length);
+		ASTNode node = finder.getCoveredNode() != null ? finder.getCoveredNode() : finder.getCoveringNode();
+		IBinding binding = resolveBinding(node);
+		if (binding != null) {
+			return new IJavaElement[] { binding.getJavaElement() };
+		}
+		return new IJavaElement[0];
+	} else {
+		return super.codeSelect(this, offset, length, workingCopyOwner);
+	}
 }
+static IBinding resolveBinding(ASTNode node) {
+	if (node instanceof MethodDeclaration decl) {
+		return decl.resolveBinding();
+	}
+	if (node instanceof MethodInvocation invocation) {
+		return invocation.resolveMethodBinding();
+	}
+	if (node instanceof VariableDeclaration decl) {
+		return decl.resolveBinding();
+	}
+	if (node instanceof FieldAccess access) {
+		return access.resolveFieldBinding();
+	}
+	if (node instanceof Type type) {
+		return type.resolveBinding();
+	}
+	if (node instanceof Name aName) {
+		ClassInstanceCreation newInstance = findConstructor(aName);
+		if (newInstance != null) {
+			return newInstance.resolveConstructorBinding();
+		}
+		IBinding res = aName.resolveBinding();
+		if (res != null) {
+			return res;
+		}
+		return resolveBinding(aName.getParent());
+	}
+	if (node instanceof org.eclipse.jdt.core.dom.LambdaExpression lambda) {
+		return lambda.resolveMethodBinding();
+	}
+	if (node instanceof MethodReference methodRef) {
+		return methodRef.resolveMethodBinding();
+	}
+	if (node instanceof org.eclipse.jdt.core.dom.TypeParameter typeParameter) {
+		return typeParameter.resolveBinding();
+	}
+	return null;
+}
+
+
+private static ClassInstanceCreation findConstructor(ASTNode node) {
+	while (node != null && !(node instanceof ClassInstanceCreation)) {
+		ASTNode parent = node.getParent();
+		if ((parent instanceof SimpleType type && type.getName() == node) ||
+			(parent instanceof ClassInstanceCreation constructor && constructor.getType() == node) ||
+			(parent instanceof ParameterizedType parameterized && parameterized.getType() == node)) {
+			node = parent;
+		} else {
+			node = null;
+		}
+	}
+	return (ClassInstanceCreation)node;
+}
+
+
+private org.eclipse.jdt.core.dom.CompilationUnit getOrBuildAST(WorkingCopyOwner workingCopyOwner) {
+	if (this.ast == null) {
+		ASTParser parser = ASTParser.newParser(AST.getJLSLatest()); // TODO use Java project info
+		parser.setSource(this);
+		// greedily enable everything assuming the AST will be used extensively for edition
+		parser.setResolveBindings(true);
+		parser.setStatementsRecovery(true);
+		parser.setBindingsRecovery(true);
+		if (parser.createAST(null) instanceof org.eclipse.jdt.core.dom.CompilationUnit newAST) {
+			this.ast = newAST;
+		}
+	}
+	return this.ast;
+}
+
+
 /**
  * @see IWorkingCopy#commit(boolean, IProgressMonitor)
  * @deprecated
@@ -1137,7 +1282,7 @@ public org.eclipse.jdt.core.dom.CompilationUnit makeConsistent(int astLevel, boo
 			openWhenClosed(info, true, monitor);
 			org.eclipse.jdt.core.dom.CompilationUnit result = info.ast;
 			info.ast = null;
-			return result;
+			return astLevel != NO_AST ? result : null;
 		} else {
 			openWhenClosed(createElementInfo(), true, monitor);
 			return null;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
@@ -448,7 +448,10 @@ public IJavaElement[] codeSelect(int offset, int length, WorkingCopyOwner workin
 		ASTNode node = finder.getCoveredNode() != null ? finder.getCoveredNode() : finder.getCoveringNode();
 		IBinding binding = resolveBinding(node);
 		if (binding != null) {
-			return new IJavaElement[] { binding.getJavaElement() };
+			IJavaElement element = binding.getJavaElement();
+			if (element != null) {
+				return new IJavaElement[] { element };
+			}
 		}
 		return new IJavaElement[0];
 	} else {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMCompletionEngine.java
@@ -1,0 +1,188 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.internal.core;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.CompletionContext;
+import org.eclipse.jdt.core.CompletionProposal;
+import org.eclipse.jdt.core.CompletionRequestor;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
+
+class DOMCompletionEngine implements Runnable {
+
+	private final int offset;
+	private final CompilationUnit unit;
+	private CompletionRequestor requestor;
+
+	DOMCompletionEngine(int offset, CompilationUnit unit, CompletionRequestor requestor, IProgressMonitor monitor) {
+		this.offset = offset;
+		this.unit = unit;
+		this.requestor = requestor;
+	}
+
+	private static Collection<? extends IBinding> visibleBindings(ASTNode node, int offset) {
+		if (node instanceof Block block) {
+			return ((List<Statement>)block.statements()).stream()
+				.filter(statement -> statement.getStartPosition() < offset)
+				.filter(VariableDeclarationStatement.class::isInstance)
+				.map(VariableDeclarationStatement.class::cast)
+				.flatMap(decl -> ((List<VariableDeclarationFragment>)decl.fragments()).stream())
+				.map(VariableDeclarationFragment::resolveBinding)
+				.toList();
+		} else if (node instanceof MethodDeclaration method) {
+			return Stream.of((List<ASTNode>)method.parameters(), (List<ASTNode>)method.typeParameters())
+				.flatMap(List::stream)
+				.map(org.eclipse.jdt.internal.core.CompilationUnit::resolveBinding)
+				.filter(Objects::nonNull)
+				.toList();
+		} else if (node instanceof TypeDeclaration type) {
+			VariableDeclarationFragment[] fields = Arrays.stream(type.getFields())
+				.map(decl -> (List<VariableDeclarationFragment>)decl.fragments())
+				.flatMap(List::stream)
+				.toArray(VariableDeclarationFragment[]::new);
+			return Stream.of(fields, type.getMethods(), type.getTypes())
+				.flatMap(Arrays::stream)
+				.map(org.eclipse.jdt.internal.core.CompilationUnit::resolveBinding)
+				.filter(Objects::nonNull)
+				.toList();
+		}
+		return List.of();
+	}
+
+	@Override
+	public void run() {
+		this.requestor.beginReporting();
+		this.requestor.acceptContext(new CompletionContext());
+		ASTNode toComplete = NodeFinder.perform(this.unit, this.offset, 0);
+		if (toComplete instanceof FieldAccess fieldAccess) {
+			processMembers(fieldAccess.resolveTypeBinding());
+		} else if (toComplete.getParent() instanceof FieldAccess fieldAccess) {
+			processMembers(fieldAccess.getExpression().resolveTypeBinding());
+		}
+		Collection<IBinding> scope = new HashSet<>();
+		ASTNode current = toComplete;
+		while (current != null) {
+			scope.addAll(visibleBindings(current, this.offset));
+			current = current.getParent();
+		}
+		// TODO also include other visible content: classpath, static methods...
+		scope.stream().map(this::toProposal).forEach(this.requestor::accept);
+		this.requestor.endReporting();
+	}
+
+	private void processMembers(ITypeBinding typeBinding) {
+		if (typeBinding == null) {
+			return;
+		}
+		Arrays.stream(typeBinding.getDeclaredFields()).map(this::toProposal).forEach(this.requestor::accept);
+		Arrays.stream(typeBinding.getDeclaredMethods()).map(this::toProposal).forEach(this.requestor::accept);
+		if (typeBinding.getInterfaces() != null) {
+			Arrays.stream(typeBinding.getInterfaces()).forEach(this::processMembers);
+		}
+		processMembers(typeBinding.getSuperclass());
+	}
+
+	private CompletionProposal toProposal(IBinding binding) {
+		int kind = 
+			binding instanceof ITypeBinding ? CompletionProposal.TYPE_REF :
+			binding instanceof IMethodBinding ? CompletionProposal.METHOD_REF :
+			binding instanceof IVariableBinding variableBinding ? CompletionProposal.LOCAL_VARIABLE_REF :
+			-1;
+		CompletionProposal res = new CompletionProposal() {
+			@Override
+			public int getKind() {
+				return kind;
+			}
+			@Override
+			public char[] getName() {
+				return binding.getName().toCharArray();
+			}
+			@Override
+			public char[] getCompletion() {
+				return binding.getName().toCharArray();
+			}
+			@Override
+			public char[] getSignature() {
+				if (binding instanceof IMethodBinding methodBinding) {
+					return Signature.createMethodSignature(
+							Arrays.stream(methodBinding.getParameterTypes())
+								.map(ITypeBinding::getName)
+								.map(String::toCharArray)
+								.map(type -> Signature.createTypeSignature(type, true).toCharArray())
+								.toArray(char[][]::new),
+							Signature.createTypeSignature(methodBinding.getReturnType().getQualifiedName().toCharArray(), true).toCharArray());
+				}
+				if (binding instanceof IVariableBinding variableBinding) {
+					return Signature.createTypeSignature(variableBinding.getType().getQualifiedName().toCharArray(), true).toCharArray();
+				}
+				if (binding instanceof ITypeBinding typeBinding) {
+					return Signature.createTypeSignature(typeBinding.getQualifiedName().toCharArray(), true).toCharArray();
+				}
+				return new char[] {};
+			}
+			@Override
+			public int getReplaceStart() {
+				return DOMCompletionEngine.this.offset;
+			}
+			@Override
+			public int getReplaceEnd() {
+				return getReplaceStart();
+			}
+			@Override
+			public int getFlags() {
+				return 0; //TODO
+			}
+			@Override
+			public char[] getReceiverSignature() {
+				if (binding instanceof IMethodBinding method) {
+					return Signature.createTypeSignature(method.getDeclaredReceiverType().getQualifiedName().toCharArray(), true).toCharArray();
+				}
+				if (binding instanceof IVariableBinding variable && variable.isField()) {
+					return Signature.createTypeSignature(variable.getDeclaringClass().getQualifiedName().toCharArray(), true).toCharArray();
+				}
+				return new char[]{};
+			}
+			@Override
+			public char[] getDeclarationSignature() {
+				if (binding instanceof IMethodBinding method) {
+					return Signature.createTypeSignature(method.getDeclaringClass().getQualifiedName().toCharArray(), true).toCharArray();
+				}
+				if (binding instanceof IVariableBinding variable && variable.isField()) {
+					return Signature.createTypeSignature(variable.getDeclaringClass().getQualifiedName().toCharArray(), true).toCharArray();
+				}
+				return new char[]{};
+			}
+		};
+		return res;
+	}
+
+}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
@@ -1,0 +1,1078 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.internal.core;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Stack;
+import java.util.stream.Stream;
+
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.IAnnotation;
+import org.eclipse.jdt.core.IImportDeclaration;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMemberValuePair;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.compiler.InvalidInputException;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AbstractTagElement;
+import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
+import org.eclipse.jdt.core.dom.AnnotationTypeMemberDeclaration;
+import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
+import org.eclipse.jdt.core.dom.ArrayInitializer;
+import org.eclipse.jdt.core.dom.BodyDeclaration;
+import org.eclipse.jdt.core.dom.BooleanLiteral;
+import org.eclipse.jdt.core.dom.CharacterLiteral;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.Comment;
+import org.eclipse.jdt.core.dom.EnumConstantDeclaration;
+import org.eclipse.jdt.core.dom.EnumDeclaration;
+import org.eclipse.jdt.core.dom.ExportsDirective;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.Initializer;
+import org.eclipse.jdt.core.dom.MarkerAnnotation;
+import org.eclipse.jdt.core.dom.MemberValuePair;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.ModuleDeclaration;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NormalAnnotation;
+import org.eclipse.jdt.core.dom.NullLiteral;
+import org.eclipse.jdt.core.dom.NumberLiteral;
+import org.eclipse.jdt.core.dom.OpensDirective;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
+import org.eclipse.jdt.core.dom.PrefixExpression;
+import org.eclipse.jdt.core.dom.ProvidesDirective;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.RecordDeclaration;
+import org.eclipse.jdt.core.dom.RequiresDirective;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.jdt.core.dom.TagElement;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeLiteral;
+import org.eclipse.jdt.core.dom.UsesDirective;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
+import org.eclipse.jdt.internal.compiler.parser.RecoveryScanner;
+import org.eclipse.jdt.internal.compiler.parser.Scanner;
+import org.eclipse.jdt.internal.compiler.parser.TerminalTokens;
+import org.eclipse.jdt.internal.core.ModuleDescriptionInfo.ModuleReferenceInfo;
+import org.eclipse.jdt.internal.core.ModuleDescriptionInfo.PackageExportInfo;
+import org.eclipse.jdt.internal.core.ModuleDescriptionInfo.ServiceInfo;
+import org.eclipse.jdt.internal.core.util.Util;
+
+/**
+ * Process an AST to populate a tree of IJavaElement->JavaElementInfo.
+ * DOM-first approach to what legacy implements through ECJ parser and CompilationUnitStructureRequestor
+ */
+class DOMToModelPopulator extends ASTVisitor {
+
+	private final Map<IJavaElement, IElementInfo> toPopulate;
+	private final Stack<JavaElement> elements = new Stack<>();
+	private final Stack<JavaElementInfo> infos = new Stack<>();
+	private final Set<String> currentTypeParameters = new HashSet<>();
+	private final CompilationUnitElementInfo unitInfo;
+	private ImportContainer importContainer;
+	private ImportContainerInfo importContainerInfo;
+	private final CompilationUnit root;
+	private Boolean alternativeDeprecated = null;
+
+	public DOMToModelPopulator(Map<IJavaElement, IElementInfo> newElements, CompilationUnit root, CompilationUnitElementInfo unitInfo) {
+		this.toPopulate = newElements;
+		this.elements.push(root);
+		this.infos.push(unitInfo);
+		this.root = root;
+		this.unitInfo = unitInfo;
+	}
+
+	private static void addAsChild(JavaElementInfo parentInfo, IJavaElement childElement) {
+		if (childElement instanceof SourceRefElement element) {
+			while (Stream.of(parentInfo.getChildren())
+				.filter(other -> other.getElementType() == element.getElementType())
+				.filter(other -> Objects.equals(other.getHandleIdentifier(), element.getHandleIdentifier()))
+				.findAny().isPresent()) {
+					element.incOccurrenceCount();
+			}
+		}
+		if (parentInfo instanceof AnnotatableInfo annotable && childElement instanceof IAnnotation annotation) {
+			IAnnotation[] newAnnotations = Arrays.copyOf(annotable.annotations, annotable.annotations.length + 1);
+			newAnnotations[newAnnotations.length - 1] = annotation;
+			annotable.annotations = newAnnotations;
+			return;
+		}
+		if (childElement instanceof TypeParameter typeParam) {
+			if (parentInfo instanceof SourceTypeElementInfo type) {
+				type.typeParameters = Arrays.copyOf(type.typeParameters, type.typeParameters.length + 1);
+				type.typeParameters[type.typeParameters.length - 1] = typeParam;
+				return;
+			}
+			if (parentInfo instanceof SourceMethodElementInfo method) {
+				method.typeParameters = Arrays.copyOf(method.typeParameters, method.typeParameters.length + 1);
+				method.typeParameters[method.typeParameters.length - 1] = typeParam;
+				return;
+			}
+		}
+		if (parentInfo instanceof ImportContainerInfo importContainer && childElement instanceof org.eclipse.jdt.internal.core.ImportDeclaration importDecl) {
+			IJavaElement[] newImports = Arrays.copyOf(importContainer.getChildren(), importContainer.getChildren().length + 1);
+			newImports[newImports.length - 1] = importDecl;
+			importContainer.children = newImports;
+			return;
+		}
+		// if nothing more specialized, add as child
+		if (parentInfo instanceof SourceTypeElementInfo type) {
+			type.children = Arrays.copyOf(type.children, type.children.length + 1);
+			type.children[type.children.length - 1] = childElement;
+			return;
+		}
+		if (parentInfo instanceof OpenableElementInfo openable) {
+			openable.addChild(childElement);
+			return;
+		}
+		if (parentInfo instanceof SourceMethodWithChildrenInfo method) {
+			IJavaElement[] newElements = Arrays.copyOf(method.children, method.children.length + 1);
+			newElements[newElements.length - 1] = childElement;
+			method.children = newElements;
+			return;
+		}
+	}
+
+	@Override
+	public boolean visit(org.eclipse.jdt.core.dom.CompilationUnit node) {
+		this.unitInfo.setSourceLength(node.getLength());
+		return true;
+	}
+
+	@Override
+	public boolean visit(PackageDeclaration node) {
+		org.eclipse.jdt.internal.core.PackageDeclaration newElement = new org.eclipse.jdt.internal.core.PackageDeclaration(this.root, node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		AnnotatableInfo newInfo = new AnnotatableInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(PackageDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(ImportDeclaration node) {
+		if (this.importContainer == null) {
+			this.importContainer = this.root.getImportContainer();
+			this.importContainerInfo = new ImportContainerInfo();
+			JavaElementInfo parentInfo = this.infos.peek();
+			addAsChild(parentInfo, this.importContainer);
+			this.toPopulate.put(this.importContainer, this.importContainerInfo);
+		}
+		org.eclipse.jdt.internal.core.ImportDeclaration newElement = new org.eclipse.jdt.internal.core.ImportDeclaration(this.importContainer, node.getName().toString(), node.isOnDemand());
+		this.elements.push(newElement);
+		addAsChild(this.importContainerInfo, newElement);
+		ImportDeclarationElementInfo newInfo = new ImportDeclarationElementInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		int nameSourceEnd = node.getName().getStartPosition() + node.getName().getLength() - 1;
+		if (node.isOnDemand()) {
+			nameSourceEnd = node.getStartPosition() + node.getLength() - 1;
+			char[] contents = this.root.getContents();
+			List<Comment> comments = domUnit(node).getCommentList();
+			boolean changed = false;
+			do {
+				while (contents[nameSourceEnd] == ';' || Character.isWhitespace(contents[nameSourceEnd])) {
+					nameSourceEnd--;
+					changed = true;
+				}
+				final int currentEnd = nameSourceEnd;
+				int newEnd = comments.stream()
+					.filter(comment -> comment.getStartPosition() <= currentEnd && comment.getStartPosition() + comment.getLength() >= currentEnd)
+					.findAny()
+					.map(comment -> comment.getStartPosition() - 1)
+					.orElse(currentEnd);
+				changed = (currentEnd != newEnd);
+				nameSourceEnd = newEnd;
+			} while (changed);
+		}
+		newInfo.setNameSourceEnd(nameSourceEnd);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(ImportDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(TypeDeclaration node) {
+		if (node.getAST().apiLevel() > 2) {
+			((List<org.eclipse.jdt.core.dom.TypeParameter>)node.typeParameters())
+				.stream()
+				.map(org.eclipse.jdt.core.dom.TypeParameter::getName)
+				.map(Name::getFullyQualifiedName)
+				.forEach(this.currentTypeParameters::add);
+		}
+		SourceType newElement = new SourceType(this.elements.peek(), node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceTypeElementInfo newInfo = new SourceTypeElementInfo();
+		boolean isDeprecated = isNodeDeprecated(node);
+		char[][] categories = getCategories(node);
+		newInfo.addCategories(newElement, categories);
+		JavaElementInfo toPopulateCategories = this.infos.peek();
+		while (toPopulateCategories != null) {
+			if (toPopulateCategories instanceof SourceTypeElementInfo parentTypeInfo) {
+				parentTypeInfo.addCategories(newElement, categories);
+				toPopulateCategories = (JavaElementInfo)parentTypeInfo.getEnclosingType();
+			} else {
+				break;
+			}
+		}
+		if (node.getAST().apiLevel() > 2) {
+			newInfo.setSuperInterfaceNames(((List<Type>)node.superInterfaceTypes()).stream().map(Type::toString).map(String::toCharArray).toArray(char[][]::new));
+		}
+		if (node.getAST().apiLevel() > 2 && node.getSuperclassType() != null) {
+			newInfo.setSuperclassName(node.getSuperclassType().toString().toCharArray());
+		}
+		if (node.getAST().apiLevel() >= AST.JLS17) {
+			newInfo.setPermittedSubtypeNames(((List<Type>)node.permittedTypes()).stream().map(Type::toString).map(String::toCharArray).toArray(char[][]::new));
+		}
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.setFlags(node.getModifiers()
+			| (isDeprecated ? ClassFileConstants.AccDeprecated : 0)
+			| (node.isInterface() ? Flags.AccInterface : 0));
+
+		newInfo.setHandle(newElement);
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(TypeDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+		if (decl.getAST().apiLevel() > 2) {
+			((List<org.eclipse.jdt.core.dom.TypeParameter>)decl.typeParameters())
+				.stream()
+				.map(org.eclipse.jdt.core.dom.TypeParameter::getName)
+				.map(Name::getFullyQualifiedName)
+				.forEach(this.currentTypeParameters::remove);
+		}
+	}
+
+	@Override
+	public boolean visit(AnnotationTypeDeclaration node) {
+		SourceType newElement = new SourceType(this.elements.peek(), node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceTypeElementInfo newInfo = new SourceTypeElementInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		char[][] categories = getCategories(node);
+		newInfo.addCategories(newElement, categories);
+		JavaElementInfo toPopulateCategories = this.infos.peek();
+		while (toPopulateCategories != null) {
+			if (toPopulateCategories instanceof SourceTypeElementInfo parentTypeInfo) {
+				parentTypeInfo.addCategories(newElement, categories);
+				toPopulateCategories = (JavaElementInfo)parentTypeInfo.getEnclosingType();
+			} else {
+				break;
+			}
+		}
+		boolean isDeprecated = isNodeDeprecated(node);
+		newInfo.setFlags(node.getModifiers() | ClassFileConstants.AccInterface|Flags.AccAnnotation | (isDeprecated ? ClassFileConstants.AccDeprecated : 0));
+		newInfo.setHandle(newElement);
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+
+	@Override
+	public void endVisit(AnnotationTypeDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(EnumDeclaration node) {
+		SourceType newElement = new SourceType(this.elements.peek(), node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceTypeElementInfo newInfo = new SourceTypeElementInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		char[][] categories = getCategories(node);
+		newInfo.addCategories(newElement, categories);
+		JavaElementInfo toPopulateCategories = this.infos.peek();
+		while (toPopulateCategories != null) {
+			if (toPopulateCategories instanceof SourceTypeElementInfo parentTypeInfo) {
+				parentTypeInfo.addCategories(newElement, categories);
+				toPopulateCategories = (JavaElementInfo)parentTypeInfo.getEnclosingType();
+			} else {
+				break;
+			}
+		}
+		boolean isDeprecated = isNodeDeprecated(node);
+		newInfo.setFlags(node.getModifiers() | Flags.AccEnum | (isDeprecated ? ClassFileConstants.AccDeprecated : 0));
+		newInfo.setHandle(newElement);
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(EnumDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(EnumConstantDeclaration node) {
+		IJavaElement parent = this.elements.peek();
+		SourceField newElement = new SourceField(this.elements.peek(), node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceFieldElementInfo info = new SourceFieldElementInfo();
+		info.setTypeName(parent.getElementName().toCharArray());
+		info.setSourceRangeStart(node.getStartPosition());
+		info.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		boolean isDeprecated = isNodeDeprecated(node);
+		info.setFlags(node.getModifiers() | ClassFileConstants.AccEnum | (isDeprecated ? ClassFileConstants.AccDeprecated : 0));
+		info.setNameSourceStart(node.getName().getStartPosition());
+		info.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		// TODO populate info
+		this.infos.push(info);
+		this.toPopulate.put(newElement, info);
+		return true;
+	}
+	@Override
+	public void endVisit(EnumConstantDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(RecordDeclaration node) {
+		SourceType newElement = new SourceType(this.elements.peek(), node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceTypeElementInfo newInfo = new SourceTypeElementInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		char[][] categories = getCategories(node);
+		newInfo.addCategories(newElement, categories);
+		JavaElementInfo toPopulateCategories = this.infos.peek();
+		while (toPopulateCategories != null) {
+			if (toPopulateCategories instanceof SourceTypeElementInfo parentTypeInfo) {
+				parentTypeInfo.addCategories(newElement, categories);
+				toPopulateCategories = (JavaElementInfo)parentTypeInfo.getEnclosingType();
+			} else {
+				break;
+			}
+		}
+		boolean isDeprecated = isNodeDeprecated(node);
+		newInfo.setFlags(node.getModifiers() | Flags.AccRecord | (isDeprecated ? ClassFileConstants.AccDeprecated : 0));
+		newInfo.setHandle(newElement);
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(RecordDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(SingleVariableDeclaration node) {
+		if (node.getParent() instanceof RecordDeclaration) {
+			SourceField newElement = new SourceField(this.elements.peek(), node.getName().toString());
+			this.elements.push(newElement);
+			addAsChild(this.infos.peek(), newElement);
+			SourceFieldElementInfo newInfo = new SourceFieldElementInfo();
+			newInfo.setSourceRangeStart(node.getStartPosition());
+			newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+			newInfo.setNameSourceStart(node.getName().getStartPosition());
+			newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+			newInfo.setTypeName(node.getType().toString().toCharArray());
+			newInfo.isRecordComponent = true;
+			this.infos.push(newInfo);
+			this.toPopulate.put(newElement, newInfo);
+		}
+		return true;
+	}
+	@Override
+	public void endVisit(SingleVariableDeclaration decl) {
+		if (decl.getParent() instanceof RecordDeclaration recordDecl) {
+			this.elements.pop();
+			this.infos.pop();
+		}
+	}
+
+	@Override
+	public boolean visit(MethodDeclaration method) {
+		if (method.getAST().apiLevel() > 2) {
+			((List<org.eclipse.jdt.core.dom.TypeParameter>)method.typeParameters())
+				.stream()
+				.map(org.eclipse.jdt.core.dom.TypeParameter::getName)
+				.map(Name::getFullyQualifiedName)
+				.forEach(this.currentTypeParameters::add);
+		}
+		List<SingleVariableDeclaration> parameters = method.parameters();
+		if (method.getAST().apiLevel() >= AST.JLS16
+			&& method.isCompactConstructor()
+			&& (parameters == null || parameters.isEmpty())
+			&& method.getParent() instanceof RecordDeclaration parentRecord) {
+			parameters = parentRecord.recordComponents();
+		}
+		SourceMethod newElement = new SourceMethod(this.elements.peek(),
+			method.getName().getIdentifier(),
+			parameters.stream()
+				.map(this::createSignature)
+				.toArray(String[]::new));
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceMethodElementInfo info = method.isConstructor() ?
+			new SourceConstructorInfo() :
+			new SourceMethodWithChildrenInfo(new IJavaElement[0]);
+		info.setArgumentNames(parameters.stream().map(param -> param.getName().toString().toCharArray()).toArray(char[][]::new));
+		info.arguments = parameters.stream().map(this::toLocalVariable).toArray(LocalVariable[]::new);
+		if (method.getAST().apiLevel() > 2) {
+			if (method.getReturnType2() != null) {
+				info.setReturnType(method.getReturnType2().toString().toCharArray());
+			} else {
+				info.setReturnType("void".toCharArray()); //$NON-NLS-1$
+			}
+		}
+		if (this.infos.peek() instanceof SourceTypeElementInfo parentInfo) {
+			parentInfo.addCategories(newElement, getCategories(method));
+		}
+		if (method.getAST().apiLevel() >= AST.JLS8) {
+			info.setExceptionTypeNames(((List<Type>)method.thrownExceptionTypes()).stream().map(Type::toString).map(String::toCharArray).toArray(char[][]::new));
+		}
+		info.setSourceRangeStart(method.getStartPosition());
+		info.setSourceRangeEnd(method.getStartPosition() + method.getLength() - 1);
+		boolean isDeprecated = isNodeDeprecated(method);
+		info.setFlags(method.getModifiers()
+			| (isDeprecated ? ClassFileConstants.AccDeprecated : 0)
+			| ((method.getAST().apiLevel() > AST.JLS2 && ((List<SingleVariableDeclaration>)method.parameters()).stream().anyMatch(SingleVariableDeclaration::isVarargs)) ? Flags.AccVarargs : 0));
+		info.setNameSourceStart(method.getName().getStartPosition());
+		info.setNameSourceEnd(method.getName().getStartPosition() + method.getName().getLength() - 1);
+		info.isCanonicalConstructor = method.isConstructor();
+		this.infos.push(info);
+		this.toPopulate.put(newElement, info);
+		return true;
+	}
+	@Override
+	public void endVisit(MethodDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+		if (decl.getAST().apiLevel() > 2) {
+			((List<org.eclipse.jdt.core.dom.TypeParameter>)decl.typeParameters())
+				.stream()
+				.map(org.eclipse.jdt.core.dom.TypeParameter::getName)
+				.map(Name::getFullyQualifiedName)
+				.forEach(this.currentTypeParameters::remove);
+		}
+	}
+
+	@Override
+	public boolean visit(AnnotationTypeMemberDeclaration method) {
+		SourceMethod newElement = new SourceMethod(this.elements.peek(),
+			method.getName().getIdentifier(),
+			new String[0]);
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceAnnotationMethodInfo info = new SourceAnnotationMethodInfo();
+		info.setReturnType(method.getType().toString().toCharArray());
+		info.setSourceRangeStart(method.getStartPosition());
+		info.setSourceRangeEnd(method.getStartPosition() + method.getLength() - 1);
+		((SourceTypeElementInfo)this.infos.peek()).addCategories(newElement, getCategories(method));
+		boolean isDeprecated = isNodeDeprecated(method);
+		info.setFlags(method.getModifiers() | (isDeprecated ? ClassFileConstants.AccDeprecated : 0));
+		info.setNameSourceStart(method.getName().getStartPosition());
+		info.setNameSourceEnd(method.getName().getStartPosition() + method.getName().getLength() - 1);
+		Expression defaultExpr = method.getDefault();
+		if (defaultExpr != null) {
+			Entry<Object, Integer> value = memberValue(defaultExpr);
+			org.eclipse.jdt.internal.core.MemberValuePair mvp = new org.eclipse.jdt.internal.core.MemberValuePair(newElement.getElementName(), value.getKey(), value.getValue());
+			info.defaultValue = mvp;
+			info.defaultValueStart = defaultExpr.getStartPosition();
+			info.defaultValueEnd = defaultExpr.getStartPosition() + defaultExpr.getLength();
+		}
+		this.infos.push(info);
+		this.toPopulate.put(newElement, info);
+		return true;
+	}
+	@Override
+	public void endVisit(AnnotationTypeMemberDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(org.eclipse.jdt.core.dom.TypeParameter node) {
+		TypeParameter newElement = new TypeParameter(this.elements.peek(), node.getName().getFullyQualifiedName());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		TypeParameterElementInfo info = new TypeParameterElementInfo();
+		info.setSourceRangeStart(node.getStartPosition());
+		info.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		info.nameStart = node.getName().getStartPosition();
+		info.nameEnd = node.getName().getStartPosition() + node.getName().getLength() - 1;
+		info.bounds = ((List<Type>)node.typeBounds()).stream().map(Type::toString).map(String::toCharArray).toArray(char[][]::new);
+		info.boundsSignatures = ((List<Type>)node.typeBounds()).stream().map(Type::toString).map(String::toCharArray).toArray(char[][]::new);
+		this.infos.push(info);
+		this.toPopulate.put(newElement, info);
+		return true;
+	}
+	@Override
+	public void endVisit(org.eclipse.jdt.core.dom.TypeParameter typeParam) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(NormalAnnotation node) {
+		Annotation newElement = new Annotation(this.elements.peek(), node.getTypeName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		AnnotationInfo newInfo = new AnnotationInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.nameStart = node.getTypeName().getStartPosition();
+		newInfo.nameEnd = node.getTypeName().getStartPosition() + node.getTypeName().getLength() - 1;
+		newInfo.members = ((List<org.eclipse.jdt.core.dom.MemberValuePair>)node.values())
+			.stream()
+			.map(domMemberValuePair -> {
+				Entry<Object, Integer> value = memberValue(domMemberValuePair.getValue());
+				return new org.eclipse.jdt.internal.core.MemberValuePair(domMemberValuePair.getName().toString(), value.getKey(), value.getValue());
+			})
+			.toArray(IMemberValuePair[]::new);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(NormalAnnotation decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(MarkerAnnotation node) {
+		Annotation newElement = new Annotation(this.elements.peek(), node.getTypeName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		AnnotationInfo newInfo = new AnnotationInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.nameStart = node.getTypeName().getStartPosition();
+		newInfo.nameEnd = node.getTypeName().getStartPosition() + node.getTypeName().getLength() - 1;
+		newInfo.members = new IMemberValuePair[0];
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(MarkerAnnotation decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(SingleMemberAnnotation node) {
+		Annotation newElement = new Annotation(this.elements.peek(), node.getTypeName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		AnnotationInfo newInfo = new AnnotationInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.nameStart = node.getTypeName().getStartPosition();
+		newInfo.nameEnd = node.getTypeName().getStartPosition() + node.getTypeName().getLength() - 1;
+		Entry<Object, Integer> value = memberValue(node.getValue());
+		newInfo.members = new IMemberValuePair[] { new org.eclipse.jdt.internal.core.MemberValuePair("value", value.getKey(), value.getValue()) }; //$NON-NLS-1$
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(SingleMemberAnnotation decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(AnonymousClassDeclaration decl) {
+		SourceType newElement = new SourceType(this.elements.peek(), ""); //$NON-NLS-1$
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceTypeElementInfo newInfo = new SourceTypeElementInfo() {
+			@Override
+			public boolean isAnonymousMember() {
+				return true;
+			}
+		};
+		JavaElementInfo toPopulateCategories = this.infos.peek();
+		while (toPopulateCategories != null) {
+			if (toPopulateCategories instanceof SourceTypeElementInfo parentTypeInfo) {
+				toPopulateCategories = (JavaElementInfo)parentTypeInfo.getEnclosingType();
+			} else {
+				break;
+			}
+		}
+
+		newInfo.setSourceRangeEnd(decl.getStartPosition() + decl.getLength() - 1);
+		newInfo.setHandle(newElement);
+		newInfo.setSourceRangeStart(decl.getStartPosition());
+		newInfo.setSourceRangeEnd(decl.getStartPosition() + decl.getLength() - 1);
+		if (decl.getParent() instanceof ClassInstanceCreation constructorInvocation) {
+			if (constructorInvocation.getAST().apiLevel() > 2) {
+				((List<SimpleType>)constructorInvocation.typeArguments())
+					.stream()
+					.map(SimpleType::getName)
+					.map(Name::getFullyQualifiedName)
+					.forEach(this.currentTypeParameters::add);
+				newInfo.setNameSourceStart(constructorInvocation.getType().getStartPosition());
+				newInfo.setSourceRangeStart(constructorInvocation.getStartPosition());
+				newInfo.setNameSourceEnd(constructorInvocation.getType().getStartPosition() + constructorInvocation.getType().getLength() - 1);
+			} else {
+				newInfo.setNameSourceStart(constructorInvocation.getName().getStartPosition());
+				newInfo.setSourceRangeStart(constructorInvocation.getName().getStartPosition());
+				newInfo.setNameSourceEnd(constructorInvocation.getName().getStartPosition() + constructorInvocation.getName().getLength() - 1);
+			}
+		}
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(AnonymousClassDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+		if (decl.getParent() instanceof ClassInstanceCreation constructorInvocation) {
+			if (constructorInvocation.getAST().apiLevel() > 2) {
+				((List<SimpleType>)constructorInvocation.typeArguments())
+				.stream()
+				.map(SimpleType::getName)
+				.map(Name::getFullyQualifiedName)
+				.forEach(this.currentTypeParameters::remove);
+			}
+		}
+	}
+
+	public Entry<Object, Integer> memberValue(Expression dom) {
+		if (dom == null ||
+			dom instanceof NullLiteral nullLiteral ||
+			(dom instanceof SimpleName name && (
+				"MISSING".equals(name.getIdentifier()) || //$NON-NLS-1$ // better compare with internal SimpleName.MISSING
+				Arrays.equals(RecoveryScanner.FAKE_IDENTIFIER, name.getIdentifier().toCharArray())))) {
+			return new SimpleEntry<>(null, IMemberValuePair.K_UNKNOWN);
+		}
+		if (dom instanceof StringLiteral stringValue) {
+			return new SimpleEntry<>(stringValue.getLiteralValue(), IMemberValuePair.K_STRING);
+		}
+		if (dom instanceof BooleanLiteral booleanValue) {
+			return new SimpleEntry<>(booleanValue.booleanValue(), IMemberValuePair.K_BOOLEAN);
+		}
+		if (dom instanceof CharacterLiteral charValue) {
+			return new SimpleEntry<>(charValue.charValue(), IMemberValuePair.K_CHAR);
+		}
+		if (dom instanceof TypeLiteral typeLiteral) {
+			return new SimpleEntry<>(typeLiteral.getType(), IMemberValuePair.K_CLASS);
+		}
+		if (dom instanceof SimpleName simpleName) {
+			return new SimpleEntry<>(simpleName.toString(), IMemberValuePair.K_SIMPLE_NAME);
+		}
+		if (dom instanceof QualifiedName qualifiedName) {
+			return new SimpleEntry<>(qualifiedName.toString(), IMemberValuePair.K_QUALIFIED_NAME);
+		}
+		if (dom instanceof org.eclipse.jdt.core.dom.Annotation annotation) {
+			return new SimpleEntry<>(toModelAnnotation(annotation), IMemberValuePair.K_ANNOTATION);
+		}
+		if (dom instanceof ArrayInitializer arrayInitializer) {
+			var values = ((List<Expression>)arrayInitializer.expressions()).stream().map(this::memberValue).toList();
+			var types = values.stream().map(Entry::getValue).distinct().toList();
+			return new SimpleEntry<>(values.stream().map(Entry::getKey).toArray(), types.size() == 1 ? types.get(0) : IMemberValuePair.K_UNKNOWN);
+		}
+		if (dom instanceof NumberLiteral number) {
+			String token = number.getToken();
+			int type = toAnnotationValuePairType(token);
+			Object value = token;
+			if ((type == IMemberValuePair.K_LONG && token.endsWith("L")) || //$NON-NLS-1$
+				(type == IMemberValuePair.K_FLOAT && token.endsWith("f"))) { //$NON-NLS-1$
+				value = token.substring(0, token.length() - 1);
+			}
+			if (value instanceof String valueString) {
+				// I tried using `yield`, but this caused ECJ to throw an AIOOB, preventing compilation
+				switch (type) {
+					case IMemberValuePair.K_INT: {
+						try {
+							value =  Integer.parseInt(valueString);
+						} catch (NumberFormatException e) {
+							type = IMemberValuePair.K_LONG;
+							value = Long.parseLong(valueString);
+						}
+						break;
+					}
+					case IMemberValuePair.K_LONG: value = Long.parseLong(valueString); break;
+					case IMemberValuePair.K_SHORT: value = Short.parseShort(valueString); break;
+					case IMemberValuePair.K_BYTE: value = Byte.parseByte(valueString); break;
+					case IMemberValuePair.K_FLOAT: value = Float.parseFloat(valueString); break;
+					case IMemberValuePair.K_DOUBLE: value = Double.parseDouble(valueString); break;
+					default: throw new IllegalArgumentException("Type not (yet?) supported"); //$NON-NLS-1$
+				}
+			}
+			return new SimpleEntry<>(value, type);
+		}
+		if (dom instanceof PrefixExpression prefixExpression) {
+			Expression operand = prefixExpression.getOperand();
+			if (!(operand instanceof NumberLiteral) && !(operand instanceof BooleanLiteral)) {
+				return new SimpleEntry<>(null, IMemberValuePair.K_UNKNOWN);
+			}
+			Entry<Object, Integer> entry = memberValue(prefixExpression.getOperand());
+			return new SimpleEntry<>(prefixExpression.getOperator().toString() + entry.getKey(), entry.getValue());
+		}
+		return new SimpleEntry<>(null, IMemberValuePair.K_UNKNOWN);
+	}
+
+	private int toAnnotationValuePairType(String token) {
+		// inspired by NumberLiteral.setToken
+		Scanner scanner = new Scanner();
+		scanner.setSource(token.toCharArray());
+		try {
+			int tokenType = scanner.getNextToken();
+			return switch(tokenType) {
+				case TerminalTokens.TokenNameDoubleLiteral -> IMemberValuePair.K_DOUBLE;
+				case TerminalTokens.TokenNameIntegerLiteral -> IMemberValuePair.K_INT;
+				case TerminalTokens.TokenNameFloatingPointLiteral -> IMemberValuePair.K_FLOAT;
+				case TerminalTokens.TokenNameLongLiteral -> IMemberValuePair.K_LONG;
+				case TerminalTokens.TokenNameMINUS ->
+					switch (scanner.getNextToken()) {
+						case TerminalTokens.TokenNameDoubleLiteral -> IMemberValuePair.K_DOUBLE;
+						case TerminalTokens.TokenNameIntegerLiteral -> IMemberValuePair.K_INT;
+						case TerminalTokens.TokenNameFloatingPointLiteral -> IMemberValuePair.K_FLOAT;
+						case TerminalTokens.TokenNameLongLiteral -> IMemberValuePair.K_LONG;
+						default -> throw new IllegalArgumentException("Invalid number literal : >" + token + "<"); //$NON-NLS-1$//$NON-NLS-2$
+					};
+				default -> throw new IllegalArgumentException("Invalid number literal : >" + token + "<"); //$NON-NLS-1$//$NON-NLS-2$
+			};
+		} catch (InvalidInputException ex) {
+			ILog.get().error(ex.getMessage(), ex);
+			return IMemberValuePair.K_UNKNOWN;
+		}
+	}
+
+	private Annotation toModelAnnotation(org.eclipse.jdt.core.dom.Annotation domAnnotation) {
+		IMemberValuePair[] members;
+		if (domAnnotation instanceof NormalAnnotation normalAnnotation) {
+			members = ((List<MemberValuePair>)normalAnnotation.values()).stream().map(domMemberValuePair -> {
+				Entry<Object, Integer> value = memberValue(domMemberValuePair.getValue());
+				return new org.eclipse.jdt.internal.core.MemberValuePair(domMemberValuePair.getName().toString(), value.getKey(), value.getValue());
+			}).toArray(IMemberValuePair[]::new);
+		} else if (domAnnotation instanceof SingleMemberAnnotation single) {
+			Entry<Object, Integer> value = memberValue(single.getValue());
+			members = new IMemberValuePair[] { new org.eclipse.jdt.internal.core.MemberValuePair("value", value.getKey(), value.getValue())}; //$NON-NLS-1$
+		} else {
+			members = new IMemberValuePair[0];
+		}
+		return new Annotation(null, domAnnotation.getTypeName().toString()) {
+			@Override
+			public IMemberValuePair[] getMemberValuePairs() {
+				return members;
+			}
+		};
+	}
+
+	private LocalVariable toLocalVariable(SingleVariableDeclaration parameter) {
+		return new LocalVariable(this.elements.peek(),
+				parameter.getName().getIdentifier(),
+				parameter.getStartPosition(),
+				parameter.getStartPosition() + parameter.getLength() - 1,
+				parameter.getName().getStartPosition(),
+				parameter.getName().getStartPosition() + parameter.getName().getLength() - 1,
+				Util.getSignature(parameter.getType()),
+				null, // TODO
+				parameter.getFlags(),
+				parameter.getParent() instanceof MethodDeclaration);
+	}
+
+	@Override
+	public boolean visit(FieldDeclaration field) {
+		JavaElementInfo parentInfo = this.infos.peek();
+		JavaElement parentElement = this.elements.peek();
+		boolean isDeprecated = isNodeDeprecated(field);
+		char[][] categories = getCategories(field);
+		for (VariableDeclarationFragment fragment : (Collection<VariableDeclarationFragment>) field.fragments()) {
+			SourceField newElement = new SourceField(parentElement, fragment.getName().toString());
+			this.elements.push(newElement);
+			addAsChild(parentInfo, newElement);
+			SourceFieldElementInfo info = new SourceFieldElementInfo();
+			info.setTypeName(field.getType().toString().toCharArray());
+			info.setSourceRangeStart(field.getStartPosition());
+			info.setSourceRangeEnd(field.getStartPosition() + field.getLength() - 1);
+			if (parentInfo instanceof SourceTypeElementInfo parentTypeInfo) {
+				parentTypeInfo.addCategories(newElement, categories);
+			}
+			info.setFlags(field.getModifiers() | (isDeprecated ? ClassFileConstants.AccDeprecated : 0));
+			info.setNameSourceStart(fragment.getName().getStartPosition());
+			info.setNameSourceEnd(fragment.getName().getStartPosition() + fragment.getName().getLength() - 1);
+			Expression initializer = fragment.getInitializer();
+			if (((field.getParent() instanceof TypeDeclaration type && type.isInterface())
+					|| Flags.isFinal(field.getModifiers()))
+			 	&& initializer != null && initializer.getStartPosition() >= 0) {
+				info.initializationSource = Arrays.copyOfRange(this.root.getContents(), initializer.getStartPosition(), initializer.getStartPosition() + initializer.getLength());
+			}
+			// TODO populate info
+			this.infos.push(info);
+			this.toPopulate.put(newElement, info);
+		}
+		return true;
+	}
+	@Override
+	public void endVisit(FieldDeclaration decl) {
+		int numFragments = decl.fragments().size();
+		for (int i = 0; i < numFragments; i++) {
+			this.elements.pop();
+			this.infos.pop();
+		}
+	}
+
+	private String createSignature(SingleVariableDeclaration decl) {
+		String initialSignature = Util.getSignature(decl.getType());
+		int extraDimensions = decl.getExtraDimensions();
+		if (decl.getAST().apiLevel() > AST.JLS2 && decl.isVarargs()) {
+			extraDimensions++;
+		}
+		return Signature.createArraySignature(initialSignature, extraDimensions);
+	}
+
+	@Override
+	public boolean visit(Initializer node) {
+		org.eclipse.jdt.internal.core.Initializer newElement = new org.eclipse.jdt.internal.core.Initializer(this.elements.peek(), 1);
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		InitializerElementInfo newInfo = new InitializerElementInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.setFlags(node.getModifiers());
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(Initializer decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(ModuleDeclaration node) {
+		SourceModule newElement = new SourceModule(this.elements.peek(), node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		this.unitInfo.setModule(newElement);
+		try {
+			this.root.getJavaProject().setModuleDescription(newElement);
+		} catch (JavaModelException e) {
+			ILog.get().error(e.getMessage(), e);
+		}
+		ModuleDescriptionInfo newInfo = new ModuleDescriptionInfo();
+		newInfo.setHandle(newElement);
+		newInfo.name = node.getName().toString().toCharArray();
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.setFlags(node.getFlags());
+		List<?> moduleStatements = node.moduleStatements();
+		newInfo.requires = moduleStatements.stream()
+			.filter(RequiresDirective.class::isInstance)
+			.map(RequiresDirective.class::cast)
+			.map(this::toModuleReferenceInfo)
+			.toArray(ModuleReferenceInfo[]::new);
+		newInfo.exports = moduleStatements.stream()
+			.filter(ExportsDirective.class::isInstance)
+			.map(ExportsDirective.class::cast)
+			.map(req -> toPackageExportInfo(req, req.getName(), req.getFlags()))
+			.toArray(PackageExportInfo[]::new);
+		newInfo.opens = moduleStatements.stream()
+			.filter(OpensDirective.class::isInstance)
+			.map(OpensDirective.class::cast)
+			.map(req -> toPackageExportInfo(req, req.getName(), req.getFlags()))
+			.toArray(PackageExportInfo[]::new);
+		newInfo.usedServices = moduleStatements.stream()
+			.filter(UsesDirective.class::isInstance)
+			.map(UsesDirective.class::cast)
+			.map(UsesDirective::getName)
+			.map(Name::toString)
+			.map(String::toCharArray)
+			.toArray(char[][]::new);
+		newInfo.services = moduleStatements.stream()
+			.filter(ProvidesDirective.class::isInstance)
+			.map(ProvidesDirective.class::cast)
+			.map(this::toServiceInfo)
+			.toArray(ServiceInfo[]::new);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(ModuleDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	private ModuleReferenceInfo toModuleReferenceInfo(RequiresDirective node) {
+		ModuleReferenceInfo res = new ModuleReferenceInfo();
+		res.modifiers = node.getModifiers();
+		res.name = node.getName().toString().toCharArray();
+		res.setSourceRangeStart(node.getStartPosition());
+		res.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		return res;
+	}
+	private PackageExportInfo toPackageExportInfo(ASTNode node, Name name, int flags) {
+		PackageExportInfo res = new PackageExportInfo();
+		res.flags = flags;
+		res.pack = name.toString().toCharArray();
+		res.setSourceRangeStart(node.getStartPosition());
+		res.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		return res;
+	}
+	private ServiceInfo toServiceInfo(ProvidesDirective node) {
+		ServiceInfo res = new ServiceInfo();
+		res.flags = node.getFlags();
+		res.serviceName = node.getName().toString().toCharArray();
+		res.implNames = ((List<Name>)node.implementations()).stream().map(Name::toString).map(String::toCharArray).toArray(char[][]::new);
+		res.setSourceRangeStart(node.getStartPosition());
+		res.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		return res;
+	}
+	private boolean isNodeDeprecated(BodyDeclaration node) {
+		if (node.getJavadoc() != null) {
+			boolean javadocDeprecated = node.getJavadoc().tags().stream() //
+					.anyMatch(tag -> {
+						return TagElement.TAG_DEPRECATED.equals(((AbstractTagElement)tag).getTagName());
+					});
+			if (javadocDeprecated) {
+				return true;
+			}
+		}
+		if (node.getAST().apiLevel() <= 2) {
+			return false;
+		}
+		return ((List<ASTNode>)node.modifiers()).stream() //
+				.anyMatch(modifier -> {
+					if (!isAnnotation(modifier)) {
+						return false;
+					}
+					String potentiallyUnqualifiedAnnotationType = ((org.eclipse.jdt.core.dom.Annotation)modifier).getTypeName().toString();
+					if ("java.lang.Deprecated".equals(potentiallyUnqualifiedAnnotationType)) { //$NON-NLS-1$
+						return true;
+					}
+					return "Deprecated".equals(potentiallyUnqualifiedAnnotationType) && !hasAlternativeDeprecated(); //$NON-NLS-1$
+				});
+	}
+	private static boolean isAnnotation(ASTNode node) {
+		int nodeType = node.getNodeType();
+		return nodeType == ASTNode.MARKER_ANNOTATION || nodeType == ASTNode.SINGLE_MEMBER_ANNOTATION
+				|| nodeType == ASTNode.NORMAL_ANNOTATION;
+	}
+	private boolean hasAlternativeDeprecated() {
+		if (this.alternativeDeprecated != null) {
+			return this.alternativeDeprecated;
+		}
+		if (this.importContainer != null) {
+			try {
+				IJavaElement[] importElements = this.importContainer.getChildren();
+				for (IJavaElement child : importElements) {
+					IImportDeclaration importDeclaration = (IImportDeclaration) child;
+					// It's possible that the user has imported
+					// an annotation called "Deprecated" using a wildcard import
+					// that replaces "java.lang.Deprecated"
+					// However, it's very costly and complex to check if they've done this,
+					// so I haven't bothered.
+					if (!importDeclaration.isOnDemand()
+							&& importDeclaration.getElementName().endsWith("Deprecated")) { //$NON-NLS-1$
+						this.alternativeDeprecated = true;
+						return this.alternativeDeprecated;
+					}
+				}
+			} catch (JavaModelException e) {
+				// do nothing
+			}
+		}
+		this.alternativeDeprecated = false;
+		return this.alternativeDeprecated;
+	}
+	private char[][] getCategories(BodyDeclaration decl) {
+		if (decl.getJavadoc() != null) {
+			return ((List<AbstractTagElement>)decl.getJavadoc().tags()).stream() //
+					.filter(tag -> "@category".equals(tag.getTagName()) && ((List<ASTNode>)tag.fragments()).size() > 0) //$NON-NLS-1$
+					.map(tag -> ((List<ASTNode>)tag.fragments()).get(0)) //
+					.map(fragment -> {
+						String fragmentString = fragment.toString();
+						/**
+						 * I think this is a bug in JDT, but I am replicating the behaviour.
+						 *
+						 * @see CompilationUnitTests.testGetCategories13()
+						 */
+						int firstAsterix = fragmentString.indexOf('*');
+						return fragmentString.substring(0, firstAsterix != -1 ? firstAsterix : fragmentString.length());
+					}) //
+					.flatMap(fragment -> (Stream<String>)Stream.of(fragment.split("\\s+"))) // //$NON-NLS-1$
+					.filter(category -> category.length() > 0) //
+					.map(category -> (category).toCharArray()) //
+					.toArray(char[][]::new);
+		}
+		return new char[0][0];
+	}
+
+	private static org.eclipse.jdt.core.dom.CompilationUnit domUnit(ASTNode node) {
+		while (node != null && !(node instanceof org.eclipse.jdt.core.dom.CompilationUnit)) {
+			node = node.getParent();
+		}
+		return (org.eclipse.jdt.core.dom.CompilationUnit)node;
+	}
+}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -25,6 +26,8 @@ import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.CompilationParticipant;
 import org.eclipse.jdt.core.compiler.ReconcileContext;
 import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.PrimitiveType;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
@@ -175,7 +178,6 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 		if (this.ast != null)
 			return this.ast; // no need to recompute AST if known already
 
-		CompilationUnitDeclaration unit = null;
 		try {
 			JavaModelManager.getJavaModelManager().abortOnMissingSource.set(Boolean.TRUE);
 			CompilationUnit source = workingCopy.cloneCachingContents();
@@ -183,33 +185,60 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 			if (JavaProject.hasJavaNature(workingCopy.getJavaProject().getProject())
 					&& (this.reconcileFlags & ICompilationUnit.FORCE_PROBLEM_DETECTION) != 0) {
 				this.resolveBindings = this.requestorIsActive;
-				if (this.problems == null)
+				if (this.problems == null) {
 					this.problems = new HashMap<>();
-				unit =
-					CompilationUnitProblemFinder.process(
-						source,
-						this.workingCopyOwner,
-						this.problems,
-						this.astLevel != ICompilationUnit.NO_AST/*creating AST if level is not NO_AST */,
-						this.reconcileFlags,
-						this.progressMonitor);
-				if (this.progressMonitor != null) this.progressMonitor.worked(1);
-			}
-
-			// create AST if needed
-			if (this.astLevel != ICompilationUnit.NO_AST
-					&& unit !=null/*unit is null if working copy is consistent && (problem detection not forced || non-Java project) -> don't create AST as per API*/) {
+				}
 				Map<String, String> options = workingCopy.getJavaProject().getOptions(true);
-				// convert AST
-				this.ast =
-					AST.convertCompilationUnit(
-						this.astLevel,
-						unit,
-						options,
-						this.resolveBindings,
-						source,
-						this.reconcileFlags,
-						this.progressMonitor);
+				if (CompilationUnit.DOM_BASED_OPERATIONS) {
+					ASTParser parser = ASTParser.newParser(this.astLevel > 0 ? this.astLevel : AST.getJLSLatest());
+					parser.setResolveBindings(this.resolveBindings || (this.reconcileFlags & ICompilationUnit.FORCE_PROBLEM_DETECTION) != 0);
+					parser.setCompilerOptions(options);
+					parser.setSource(source);
+					org.eclipse.jdt.core.dom.CompilationUnit newAST = (org.eclipse.jdt.core.dom.CompilationUnit) parser.createAST(this.progressMonitor);
+					if ((this.reconcileFlags & ICompilationUnit.FORCE_PROBLEM_DETECTION) != 0 && newAST != null) {
+						newAST.getAST().resolveWellKnownType(PrimitiveType.BOOLEAN.toString()); //trigger resolution and analysis
+					}
+					CategorizedProblem[] newProblems = Arrays.stream(newAST.getProblems())
+						.filter(CategorizedProblem.class::isInstance)
+						.map(CategorizedProblem.class::cast)
+						.toArray(CategorizedProblem[]::new);
+					this.problems.put(Integer.toString(CategorizedProblem.CAT_UNSPECIFIED), newProblems); // TODO better category
+					if (this.astLevel != ICompilationUnit.NO_AST) {
+						this.ast = newAST;
+					}
+				} else {
+					CompilationUnitDeclaration unit = null; 
+					try {
+						unit = CompilationUnitProblemFinder.process(
+								source,
+								this.workingCopyOwner,
+								this.problems,
+								this.astLevel != ICompilationUnit.NO_AST/*creating AST if level is not NO_AST */,
+								this.reconcileFlags,
+								this.progressMonitor);
+						if (this.progressMonitor != null) this.progressMonitor.worked(1);
+		
+						// create AST if needed
+						if (this.astLevel != ICompilationUnit.NO_AST
+								&& unit !=null/*unit is null if working copy is consistent && (problem detection not forced || non-Java project) -> don't create AST as per API*/) {
+							// convert AST
+							this.ast =
+								AST.convertCompilationUnit(
+									this.astLevel,
+									unit,
+									options,
+									this.resolveBindings,
+									source,
+									this.reconcileFlags,
+									this.progressMonitor);
+						}
+					} finally {
+						if (unit != null) {
+							unit.cleanUp();
+						}
+					}
+				}
+
 				if (this.ast != null) {
 					if (this.deltaBuilder.delta == null) {
 						this.deltaBuilder.delta = new JavaElementDelta(workingCopy);
@@ -225,9 +254,6 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 	    	// (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=100919)
 	    } finally {
 			JavaModelManager.getJavaModelManager().abortOnMissingSource.remove();
-	        if (unit != null) {
-	            unit.cleanUp();
-	        }
 	    }
 		return this.ast;
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/CommentRecorderParser.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/CommentRecorderParser.java
@@ -54,7 +54,7 @@ public class CommentRecorderParser extends Parser {
 		int lastCommentIndex = -1;
 
 		//since jdk1.2 look only in the last java doc comment...
-		nextComment : for (lastCommentIndex = this.scanner.commentPtr; lastCommentIndex >= 0; lastCommentIndex--){
+		nextComment : for (lastCommentIndex = getCommentPtr(); lastCommentIndex >= 0; lastCommentIndex--){
 			//look for @deprecated into the first javadoc comment preceeding the declaration
 			int commentSourceStart = this.scanner.commentStarts[lastCommentIndex];
 			// javadoc only (non javadoc comment have negative start and/or end positions.)

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchDocument.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchDocument.java
@@ -87,7 +87,7 @@ public class JavaSearchDocument extends SearchDocument {
 		}
 		return null;
 	}
-	private IFile getFile() {
+	public IFile getFile() {
 		if (this.file == null)
 			this.file = ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(getPath()));
 		return this.file;

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/DOMToIndexVisitor.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/DOMToIndexVisitor.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.internal.core.search.indexing;
+
+import java.util.List;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.jdt.core.dom.RecordDeclaration;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+
+class DOMToIndexVisitor extends ASTVisitor {
+
+	private SourceIndexer sourceIndexer;
+
+	public DOMToIndexVisitor(SourceIndexer sourceIndexer) {
+		this.sourceIndexer = sourceIndexer;
+	}
+
+	@Override
+	public boolean visit(TypeDeclaration type) {
+		if (type.isInterface()) {
+			this.sourceIndexer.addInterfaceDeclaration(type.getModifiers(), getPackage(type), type.getName().toString().toCharArray(), null, ((List<Type>)type.superInterfaceTypes()).stream().map(superInterface -> superInterface.toString().toCharArray()).toArray(char[][]::new), null, false);
+		} else {
+			this.sourceIndexer.addClassDeclaration(type.getModifiers(), getPackage(type), type.getName().toString().toCharArray(), null, type.getSuperclassType() == null ? null : type.getSuperclassType().toString().toCharArray(),
+				((List<Type>)type.superInterfaceTypes()).stream().map(superInterface -> superInterface.toString().toCharArray()).toArray(char[][]::new), null, isSecondary(type));
+		}
+		// TODO other types
+		return true;
+	}
+
+	private boolean isSecondary(TypeDeclaration type) {
+		return type.getParent() instanceof CompilationUnit unit &&
+			unit.types().size() > 1 &&
+			unit.types().indexOf(type) > 0;
+			// TODO: check name?
+	}
+
+	private char[] getPackage(ASTNode node) {
+		while (node != null && !(node instanceof CompilationUnit)) {
+			node = node.getParent();
+		}
+		return node == null ? null :
+			node instanceof CompilationUnit unit && unit.getPackage() != null ? unit.getPackage().getName().toString().toCharArray() :
+			null; 
+	}
+
+	@Override
+	public boolean visit(RecordDeclaration recordDecl) {
+		// copied processing of TypeDeclaration
+		this.sourceIndexer.addClassDeclaration(recordDecl.getModifiers(), getPackage(recordDecl), recordDecl.getName().toString().toCharArray(), null, null,
+				((List<Type>)recordDecl.superInterfaceTypes()).stream().map(type -> type.toString().toCharArray()).toArray(char[][]::new), null, false);
+		return true;
+	}
+
+	@Override
+	public boolean visit(MethodDeclaration method) {
+		char[] methodName = method.getName().toString().toCharArray();
+		char[][] parameterTypes = ((List<VariableDeclaration>)method.parameters()).stream()
+			.filter(SingleVariableDeclaration.class::isInstance)
+			.map(SingleVariableDeclaration.class::cast)
+			.map(SingleVariableDeclaration::getType)
+			.map(Type::toString)
+			.map(String::toCharArray)
+			.toArray(char[][]::new);
+		char[] returnType = null;
+		if (method.getReturnType2() instanceof SimpleType simple) {
+			returnType = simple.getName().toString().toCharArray();
+		} else if (method.getReturnType2() instanceof PrimitiveType primitive) {
+			returnType = primitive.getPrimitiveTypeCode().toString().toCharArray();
+		} else if (method.getReturnType2() == null) {
+			// do nothing
+		} else {
+			returnType = method.getReturnType2().toString().toCharArray();
+		}
+		char[][] exceptionTypes = ((List<Type>)method.thrownExceptionTypes()).stream()
+			.map(Type::toString)
+			.map(String::toCharArray)
+			.toArray(char[][]::new);
+		this.sourceIndexer.addMethodDeclaration(methodName, parameterTypes, returnType, exceptionTypes);
+		char[][] parameterNames = ((List<VariableDeclaration>)method.parameters()).stream()
+			.map(VariableDeclaration::getName)
+			.map(SimpleName::toString)
+			.map(String::toCharArray)
+			.toArray(char[][]::new);
+		this.sourceIndexer.addMethodDeclaration(null,
+			null /* TODO: fully qualified name of enclosing type? */,
+			methodName,
+			parameterTypes.length,
+			null,
+			parameterTypes,
+			parameterNames,
+			returnType,
+			method.getModifiers(),
+			getPackage(method),
+			0 /* TODO What to put here? */,
+			exceptionTypes,
+			0 /* TODO ExtraFlags.IsLocalType ? */);
+		return true;
+	}
+
+	@Override
+	public boolean visit(FieldDeclaration field) {
+		char[] typeName = field.getType().toString().toCharArray();
+		for (VariableDeclarationFragment fragment: (List<VariableDeclarationFragment>)field.fragments()) {
+			this.sourceIndexer.addFieldDeclaration(typeName, fragment.getName().toString().toCharArray());
+		}
+		return true;
+	}
+	
+	// TODO (cf SourceIndexer and SourceIndexerRequestor)
+	// * Module: addModuleDeclaration/addModuleReference/addModuleExportedPackages
+	// * Lambda: addIndexEntry/addClassDeclaration
+	// * addMethodReference
+	// * addConstructorReference
+}


### PR DESCRIPTION
Javadoc is not included in the declarationStart by CommentRecorderParser with all those preconditions
1. CU has a package
2. Javadoc above primary type
3. An annotation with arrayInitializer value
4. Some content to recover in the CU body