### PR TITLE
For Unnamed Classes, generate the `.class` with the same name as the `.java`

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Main-Class: org.eclipse.jdt.internal.compiler.batch.Main
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Compiler for Java(TM)
 Bundle-SymbolicName: org.eclipse.jdt.core.compiler.batch
-Bundle-Version: 3.37.0.qualifier
+Bundle-Version: 3.38.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse.org
 Automatic-Module-Name: org.eclipse.jdt.core.compiler.batch

--- a/org.eclipse.jdt.core.compiler.batch/pom.xml
+++ b/org.eclipse.jdt.core.compiler.batch/pom.xml
@@ -17,7 +17,7 @@
     <version>4.31.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core.compiler.batch</artifactId>
-  <version>3.37.0-SNAPSHOT</version>
+  <version>3.38.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UnnamedClass.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UnnamedClass.java
@@ -12,7 +12,6 @@ package org.eclipse.jdt.internal.compiler.ast;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.MessageFormat;
 
 import org.eclipse.jdt.internal.compiler.CompilationResult;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
@@ -22,23 +21,20 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
  */
 public class UnnamedClass extends TypeDeclaration {
 
-	private static String NAME_TEMPLATE = "<unnamed_class${0}>"; //$NON-NLS-1$
-
 	public UnnamedClass(CompilationResult result) {
 		super(result);
 		this.modifiers = ClassFileConstants.AccDefault | ClassFileConstants.AccFinal;
 
 		Path p = Paths.get(new String(result.fileName));
 		String basename = p.getFileName().toString();
-		String classSuffix;
+		String className;
 		if (basename.endsWith(".java")) { //$NON-NLS-1$
-			classSuffix = basename.substring(0, basename.length() - 5);
+			className = basename.substring(0, basename.length() - 5);
 		} else {
-			classSuffix = basename;
+			className = basename;
 		}
 
-		String nameString = MessageFormat.format(NAME_TEMPLATE, classSuffix);
-		this.name = nameString.toCharArray();
+		this.name = className.toCharArray();
 	}
 
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtraCompilerModifiers.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtraCompilerModifiers.java
@@ -55,6 +55,7 @@ public interface ExtraCompilerModifiers { // modifier constant
 	final int AccSealed = ASTNode.Bit29; // used for class/interface to set sealed
 	final int AccOverriding = ASTNode.Bit29; // record fact a method overrides another one
 	final int AccImplementing = ASTNode.Bit30; // record fact a method implements another one (it is concrete and overrides an abstract one)
+	final int AccUnnamed = ASTNode.Bit30; // used for unnamed classes
 	final int AccGenericSignature = ASTNode.Bit31; // record fact a type/method/field involves generics in its signature (and need special signature attr)
 	final int AccOutOfFlowScope = ASTNode.Bit29;
 }

--- a/org.eclipse.jdt.core.tests.builder/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.builder/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.builder; singleton:=true
-Bundle-Version: 3.12.300.qualifier
+Bundle-Version: 3.13.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.builder

--- a/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.builder</artifactId>
-  <version>3.12.300-SNAPSHOT</version>
+  <version>3.13.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.compiler;singleton:=true
-Bundle-Version: 3.13.300.qualifier
+Bundle-Version: 3.14.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.compiler,

--- a/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.compiler</artifactId>
-  <version>3.13.300-SNAPSHOT</version>
+  <version>3.14.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/ComplianceDiagnoseTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/ComplianceDiagnoseTest.java
@@ -2043,15 +2043,14 @@ public void test0042() {
 				       ^^^^
 			blah cannot be resolved to a variable
 			----------
-			""";
-
-	String expected1_3ProblemLog = expected16ProblemLog + """
-			3. ERROR in X.java (at line 14)
-				public static void main(String[] args) {
-				                   ^^^^^^^^^^^^^^^^^^^
-			The method main cannot be declared static; static methods can only be declared in a static or top level type
+			3. ERROR in X.java (at line 11)
+				public class X {
+				             ^
+			The nested type X cannot hide an enclosing type
 			----------
 			""";
+
+	String expected1_3ProblemLog = expected16ProblemLog;
 
 	String expected21ProblemLog = """
 			----------
@@ -2064,6 +2063,11 @@ public void test0042() {
 				return blah;
 				       ^^^^
 			blah cannot be resolved to a variable
+			----------
+			3. ERROR in X.java (at line 11)
+				public class X {
+				             ^
+			The nested type X cannot hide an enclosing type
 			----------
 			""";
 	runComplianceParserTest(

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/DietRecoveryTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/DietRecoveryTest.java
@@ -6082,7 +6082,7 @@ public void test102() {
 		""";
 
 	String expectedDietUnitToString = """
-final class <unnamed_class$<12454 - handling toplevel anonymous>> {
+final class <12454 - handling toplevel anonymous> {
   public class Hello {
     private static int x;
     private String blah;
@@ -6099,7 +6099,7 @@ final class <unnamed_class$<12454 - handling toplevel anonymous>> {
     public void foo() {
     }
   }
-  <unnamed_class$<12454 - handling toplevel anonymous>>() {
+  <12454 - handling toplevel anonymous>() {
   }
   void ___eval() {
   }
@@ -6107,7 +6107,7 @@ final class <unnamed_class$<12454 - handling toplevel anonymous>> {
 """;
 
 	String expectedDietPlusBodyUnitToString = """
-final class <unnamed_class$<12454 - handling toplevel anonymous>> {
+final class <12454 - handling toplevel anonymous> {
   public class Hello {
     private static int x;
     private String blah;
@@ -6126,7 +6126,7 @@ final class <unnamed_class$<12454 - handling toplevel anonymous>> {
     public void foo() {
     }
   }
-  <unnamed_class$<12454 - handling toplevel anonymous>>() {
+  <12454 - handling toplevel anonymous>() {
     super();
   }
   void ___eval() {
@@ -6150,7 +6150,7 @@ final class <unnamed_class$<12454 - handling toplevel anonymous>> {
 """;
 
 	String expectedFullUnitToString = """
-final class <unnamed_class$<12454 - handling toplevel anonymous>> {
+final class <12454 - handling toplevel anonymous> {
   public class Hello {
     private static int x;
     private String blah;
@@ -6169,7 +6169,7 @@ final class <unnamed_class$<12454 - handling toplevel anonymous>> {
     public void foo() {
     }
   }
-  <unnamed_class$<12454 - handling toplevel anonymous>>() {
+  <12454 - handling toplevel anonymous>() {
   }
   void ___eval() {
     new Runnable() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/SourceElementParserTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/SourceElementParserTest.java
@@ -4517,7 +4517,7 @@ public void test63() {
 		"int x;\n";
 
 	String expectedUnitToString =
-		"final class <unnamed_class$test63: full parse> {\n"
+		"final class test63: full parse {\n"
 		+ "\tpublic class X {\n"
 		+ "\t\tjava.lang.Object(0)\n"
 		+ "\t\tint foo() {}\n"
@@ -4578,7 +4578,7 @@ public void test64() {
 		"int x;\n";
 
 	String expectedUnitToString =
-			"final class <unnamed_class$test64: diet parse> {\n"
+			"final class test64: diet parse {\n"
 			+ "\tpublic class X {\n"
 			+ "\t\tint foo() {}\n"
 			+ "\t}\n"
@@ -4638,7 +4638,7 @@ public void test65() {
 		"int x();\n";
 
 	String expectedUnitToString =
-		"final class <unnamed_class$test65: diet parse> {\n"
+		"final class test65: diet parse {\n"
 		+ "\tpublic class X {\n"
 		+ "\t\tint foo() {}\n"
 		+ "\t}\n"
@@ -4699,7 +4699,7 @@ public void test66() {
 		"int x();\n";
 
 	String expectedUnitToString =
-		"final class <unnamed_class$test66: diet parse> {\n"
+		"final class test66: diet parse {\n"
 		+ "\tpublic interface X {\n"
 		+ "\t\tint foo() {}\n"
 		+ "\t}\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_3.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_3.java
@@ -2607,10 +2607,10 @@ public void test079() {
 			       ^^^^
 		blah cannot be resolved to a variable
 		----------
-		3. ERROR in Hello.java (at line 14)
-			public static void main(String[] args) {
-			                   ^^^^^^^^^^^^^^^^^^^
-		The method main cannot be declared static; static methods can only be declared in a static or top level type
+		3. ERROR in Hello.java (at line 11)
+			public class Hello {
+			             ^^^^^
+		The nested type Hello cannot hide an enclosing type
 		----------
 		"""
 	);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_4.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_4.java
@@ -2634,10 +2634,10 @@ public void test079() {
 			       ^^^^
 		blah cannot be resolved to a variable
 		----------
-		3. ERROR in Hello.java (at line 14)
-			public static void main(String[] args) {
-			                   ^^^^^^^^^^^^^^^^^^^
-		The method main cannot be declared static; static methods can only be declared in a static or top level type
+		3. ERROR in Hello.java (at line 11)
+			public class Hello {
+			             ^^^^^
+		The nested type Hello cannot hide an enclosing type
 		----------
 		"""
 	);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_5.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_5.java
@@ -2734,28 +2734,29 @@ public void test079() {
 			+ "	return blah;\n"
 			+ "	       ^^^^\n"
 			+ "blah cannot be resolved to a variable\n"
+			+ "----------\n"
+			+ "3. ERROR in Hello.java (at line 11)\n"
+			+ "	public class Hello {\n"
+			+ "	             ^^^^^\n"
+			+ "The nested type Hello cannot hide an enclosing type\n"
 			+ "----------\n";
-	if (this.complianceLevel < ClassFileConstants.JDK16) {
-		expectedErrorLog += "3. ERROR in Hello.java (at line 14)\n"
-			+ "	public static void main(String[] args) {\n"
-			+ "	                   ^^^^^^^^^^^^^^^^^^^\n"
-			+ "The method main cannot be declared static; static methods can only be declared in a static or top level type\n"
-			+ "----------\n";
-	}
-	if (this.complianceLevel == ClassFileConstants.JDK21) {
-		expectedErrorLog = """
-				----------
-				1. ERROR in Hello.java (at line 1)
-					void ___eval() {
-					^
-				Unnamed Classes and Instance Main Methods is a preview feature and disabled by default. Use --enable-preview to enable
-				----------
-				2. ERROR in Hello.java (at line 4)
-					return blah;
-					       ^^^^
-				blah cannot be resolved to a variable
-				----------
-				""";
+	if (ClassFileConstants.JDK21 == this.complianceLevel) {
+		expectedErrorLog = "----------\n"
+				+ "1. ERROR in Hello.java (at line 1)\n"
+				+ "	void ___eval() {\n"
+				+ "	^\n"
+				+ "Unnamed Classes and Instance Main Methods is a preview feature and disabled by default. Use --enable-preview to enable\n"
+				+ "----------\n"
+				+ "2. ERROR in Hello.java (at line 4)\n"
+				+ "	return blah;\n"
+				+ "	       ^^^^\n"
+				+ "blah cannot be resolved to a variable\n"
+				+ "----------\n"
+				+ "3. ERROR in Hello.java (at line 11)\n"
+				+ "	public class Hello {\n"
+				+ "	             ^^^^^\n"
+				+ "The nested type Hello cannot hide an enclosing type\n"
+				+ "----------\n";
 	}
 	this.runNegativeTest(
 		new String[] {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -8131,10 +8131,15 @@ public void testBug566846_2() {
 			"	^\n" +
 			"The preview feature Unnamed Classes and Instance Main Methods is only available with source level 21 and above\n" +
 			"----------\n" +
-			"2. ERROR in X.java (at line 3)\n" +
+			"2. ERROR in X.java (at line 1)\n" +
+			"	public class X {\n" +
+			"	             ^\n" +
+			"The nested type X cannot hide an enclosing type\n" +
+			"----------\n" +
+			"3. ERROR in X.java (at line 3)\n" +
 			"	record R1;\n" +
 			"	^^^^^^\n" +
-			"\'record\' is not a valid type name; it is a restricted identifier and not allowed as a type identifier in Java 16\n" +
+			"'record' is not a valid type name; it is a restricted identifier and not allowed as a type identifier in Java 16\n" +
 			"----------\n",
 			null,
 			true,

--- a/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.model;singleton:=true
-Bundle-Version: 3.12.300.qualifier
+Bundle-Version: 3.13.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests,
@@ -15,7 +15,7 @@ Export-Package: org.eclipse.jdt.core.tests,
  org.eclipse.jdt.core.tests.rewrite.modifying
 Require-Bundle: org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
- org.eclipse.jdt.core;bundle-version="[3.36.0,4.0.0)",
+ org.eclipse.jdt.core;bundle-version="[3.38.0,4.0.0)",
  org.junit;bundle-version="3.8.1",
  org.eclipse.test.performance;bundle-version="[3.1.0,4.0.0)",
  org.eclipse.jdt.core.tests.compiler;bundle-version="[3.4.0,4.0.0)",

--- a/org.eclipse.jdt.core.tests.model/pom.xml
+++ b/org.eclipse.jdt.core.tests.model/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.model</artifactId>
-  <version>3.12.300-SNAPSHOT</version>
+  <version>3.13.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
@@ -2504,9 +2504,9 @@ public void testBug459189_002() throws JavaModelException {
 	this.workingCopies[0] = getWorkingCopy(
 			"/Completion/src/X.java",
 			"	Integer bar(Integer x) { return null;}\n"+
-			"public class X {\n"+
+			"public class Y {\n"+
 			"	Integer foo(){\n"+
-			"		I <Integer, X> i2 = (x) -> {/* HERE */ret /* type ctrl-space after ret */};\n"+
+			"		I <Integer, Y> i2 = (x) -> {/* HERE */ret /* type ctrl-space after ret */};\n"+
 			"		return 0;\n"+
 			"	}\n"+
 			"}\n"+

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs21Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs21Tests.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.model;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchMatch;
+
+import junit.framework.Test;
+
+public class JavaSearchBugs21Tests extends AbstractJavaSearchTests {
+
+	public JavaSearchBugs21Tests(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		return buildModelTestSuite(JavaSearchBugs21Tests.class, BYTECODE_DECLARATION_ORDER);
+	}
+
+	class TestCollector extends JavaSearchResultCollector {
+		@Override
+		public void acceptSearchMatch(SearchMatch searchMatch) throws CoreException {
+			super.acceptSearchMatch(searchMatch);
+		}
+	}
+
+	@Override
+	IJavaSearchScope getJavaSearchScope() {
+		return SearchEngine.createJavaSearchScope(new IJavaProject[] {getJavaProject("JavaSearchBugs")});
+	}
+	IJavaSearchScope getJavaSearchScopeBugs(String packageName, boolean addSubpackages) throws JavaModelException {
+		if (packageName == null) return getJavaSearchScope();
+		return getJavaSearchPackageScope("JavaSearchBugs", packageName, addSubpackages);
+	}
+	@Override
+	public ICompilationUnit getWorkingCopy(String path, String source) throws JavaModelException {
+		if (this.wcOwner == null) {
+			this.wcOwner = new WorkingCopyOwner() {};
+		}
+		return getWorkingCopy(path, source, this.wcOwner);
+	}
+	@Override
+	public void setUpSuite() throws Exception {
+		super.setUpSuite();
+		JAVA_PROJECT = setUpJavaProject("JavaSearchBugs", "10");
+	}
+	@Override
+	public void tearDownSuite() throws Exception {
+		deleteProject("JavaSearchBugs");
+		super.tearDownSuite();
+	}
+	@Override
+	protected void setUp () throws Exception {
+		super.setUp();
+		this.resultCollector = new TestCollector();
+		this.resultCollector.showAccuracy(true);
+	}
+
+	public void testUnnamedClassInModel() throws CoreException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/JavaSearchBugs/src/X.java", """
+				String foo() {
+					return "foo";
+				}
+				void main() {
+					System.out.println(foo());
+				}
+				""");
+		IType unnamedType = this.workingCopies[0].getType("X");
+		assertTrue("Unnamed class should exist in the model", unnamedType.exists());
+		assertTrue("Unnamed class should be marked as unnamed", unnamedType.isImplicitlyDeclared());
+	}
+
+	public void testNamedClassInModel() throws CoreException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/JavaSearchBugs/src/X.java", """
+				public class X {
+					String foo() {
+						return "foo";
+					}
+					void main() {
+						System.out.println(foo());
+					}
+				}
+				""");
+		IType unnamedType = this.workingCopies[0].getType("X");
+		assertTrue("Unnamed class should exist in the model", unnamedType.exists());
+		assertTrue("Unnamed class should be marked as unnamed", !unnamedType.isImplicitlyDeclared());
+	}
+
+}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/RunJavaSearchTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/RunJavaSearchTests.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.core.tests.model;
 
 import java.lang.reflect.*;
 import java.util.*;
-import java.util.ArrayList;
 
 import org.eclipse.jdt.core.tests.junit.extension.TestCase;
 
@@ -71,6 +70,7 @@ public class RunJavaSearchTests extends junit.framework.TestCase {
 		allClasses.add(JavaSearchBugs16Tests.class);
 		allClasses.add(JavaSearchBugs17Tests.class);
 		allClasses.add(JavaSearchBugs19Tests.class);
+		allClasses.add(JavaSearchBugs21Tests.class);
 		allClasses.add(JavaSearchMultipleProjectsTests.class);
 		allClasses.add(SearchTests.class);
 		allClasses.add(JavaSearchScopeTests.class);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeHierarchyTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeHierarchyTests.java
@@ -30,20 +30,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.jdt.core.Flags;
-import org.eclipse.jdt.core.IClassFile;
-import org.eclipse.jdt.core.IClasspathEntry;
-import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.IOrdinaryClassFile;
-import org.eclipse.jdt.core.IPackageFragment;
-import org.eclipse.jdt.core.IPackageFragmentRoot;
-import org.eclipse.jdt.core.IRegion;
-import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.ITypeHierarchy;
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.tests.model.SearchTests.WaitingJob;
 import org.eclipse.jdt.core.tests.model.Semaphore.TimeOutException;
 import org.eclipse.jdt.core.tests.util.Util;
@@ -446,7 +433,7 @@ public void testBinaryInWrongPackage() throws CoreException {
 		);
 		getProject("P").build(IncrementalProjectBuilder.FULL_BUILD, null);
 		waitForAutoBuild();
-		getFile("/P/bin/p/<unnamed_class$X>.class").copy(new Path("/P/lib/X.class"), false, null);
+		getFile("/P/bin/p/X.class").copy(new Path("/P/lib/X.class"), false, null);
 		ITypeHierarchy hierarchy = getClassFile("P", "/P/lib", "", "X.class").getType().newSupertypeHierarchy(null);
 		assertHierarchyEquals(
 			"Focus: X [in X.class [in <default> [in lib [in P]]]]\n" +
@@ -3384,11 +3371,11 @@ public void testBug457813() throws CoreException {
 				"public class X extends aspose.b.a.a {\n" +
 				"}"
 			);
-		IType type = getCompilationUnit("P", "src", "hierarchy", "X.java").getType("<unnamed_class$X>");
+		IType type = getCompilationUnit("P", "src", "hierarchy", "X.java").getType("X");
 		assertTrue("Type should exist!", type.exists());
 		ITypeHierarchy hierarchy = type.newTypeHierarchy(null); // when bug occurred a stack overflow happened here...
 		assertHierarchyEquals(
-				"Focus: <unnamed_class$X> [in X.java [in hierarchy [in src [in P]]]]\n" +
+				"Focus: X [in X.java [in hierarchy [in src [in P]]]]\n" +
 				"Super types:\n" +
 				"  Object [in Object.class [in java.lang [in "+ getExternalJCLPathString() + "]]]\n" +
 				"Sub types:\n",

--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core; singleton:=true
-Bundle-Version: 3.37.0.qualifier
+Bundle-Version: 3.38.0.qualifier
 Bundle-Activator: org.eclipse.jdt.core.JavaCore
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -47,7 +47,7 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.7.0,2.0.0)",
  org.eclipse.text;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.team.core;bundle-version="[3.1.0,4.0.0)";resolution:=optional,
- org.eclipse.jdt.core.compiler.batch;bundle-version="[3.37.0,3.38.0)";visibility:=reexport
+ org.eclipse.jdt.core.compiler.batch;bundle-version="[3.38.0,3.39.0)";visibility:=reexport
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-ExtensibleAPI: true
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTMatcher.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTMatcher.java
@@ -3253,7 +3253,7 @@ public class ASTMatcher {
 	 * Returns whether the given node and the other object match.
 	 * @param node the node to check
 	 * @param other the other object
-	 * @since 3.37
+	 * @since 3.38
 	 */
 	public boolean match(UnnamedClass node, Object other) {
 		if (!(other instanceof UnnamedClass)) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTNode.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTNode.java
@@ -1101,7 +1101,7 @@ public abstract class ASTNode {
 
 	/**
 	 * @see UnnamedClass
-	 * @since 3.37
+	 * @since 3.38
 	 * @noreference This field is not intended to be referenced by clients.
 	 */
 	public static final int UNNAMED_CLASS = 118;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTVisitor.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTVisitor.java
@@ -2161,7 +2161,7 @@ public abstract class ASTVisitor {
 	 * @return <code>true</code> if the children of this node should be
 	 * visited, and <code>false</code> if the children of this node should
 	 * be skipped
-	 * @since 3.37
+	 * @since 3.38
 	 */
 	public boolean visit(UnnamedClass unnamedClass) {
 		return true;
@@ -3628,7 +3628,7 @@ public abstract class ASTVisitor {
 	 * </p>
 	 *
 	 * @param node the node to visit
-	 * @since 3.37
+	 * @since 3.38
 	 */
 	public void endVisit(UnnamedClass node) {
 		// default implementation: do nothing

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AbstractUnnamedTypeDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AbstractUnnamedTypeDeclaration.java
@@ -3,7 +3,7 @@ package org.eclipse.jdt.core.dom;
 import java.util.List;
 
 /**
- * @since 3.37
+ * @since 3.38
  */
 @SuppressWarnings("rawtypes")
 public abstract class AbstractUnnamedTypeDeclaration extends BodyDeclaration {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/UnnamedClass.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/UnnamedClass.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @since 3.37
+ * @since 3.38
  */
 public class UnnamedClass extends AbstractUnnamedTypeDeclaration {
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IType.java
@@ -944,6 +944,16 @@ public interface IType extends IMember, IAnnotatable {
 	boolean isSealed() throws JavaModelException;
 
 	/**
+	 * Returns whether this type is implicitly declared.
+	 *
+	 * @return true if this type is implicitly declared and false otherwise
+	 * @throws JavaModelException if this element does not exist or if an
+	 *		exception occurs while accessing its corresponding resource.
+	 * @since 3.38
+	 */
+	boolean isImplicitlyDeclared() throws JavaModelException;
+
+	/**
 	 * Returns the record components declared by this record class, or an empty
 	 * array if this is not a record.
 	 *

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementNotifier.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementNotifier.java
@@ -48,6 +48,7 @@ import org.eclipse.jdt.internal.compiler.ast.ThisReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.TypeParameter;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
+import org.eclipse.jdt.internal.compiler.ast.UnnamedClass;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
@@ -720,6 +721,7 @@ protected void notifySourceElementRequestor(TypeDeclaration typeDeclaration, boo
 					? (currentModifiers & ExtraCompilerModifiers.AccJustFlag) | ClassFileConstants.AccDeprecated
 					: currentModifiers & ExtraCompilerModifiers.AccJustFlag;
 			typeInfo.modifiers |= currentModifiers & (ExtraCompilerModifiers.AccSealed | ExtraCompilerModifiers.AccNonSealed);
+			typeInfo.modifiers |= typeDeclaration instanceof UnnamedClass ? ExtraCompilerModifiers.AccUnnamed : 0;
 			typeInfo.name = typeDeclaration.name;
 			typeInfo.nameSourceStart = isEnumInit ? typeDeclaration.allocation.enumConstant.sourceStart : typeDeclaration.sourceStart;
 			typeInfo.nameSourceEnd = sourceEnd(typeDeclaration);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
@@ -32,6 +32,7 @@ import org.eclipse.jdt.internal.compiler.env.IBinaryAnnotation;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
+import org.eclipse.jdt.internal.compiler.lookup.ExtraCompilerModifiers;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.core.JavaModelManager.PerProjectInfo;
 import org.eclipse.jdt.internal.core.hierarchy.TypeHierarchy;
@@ -1158,5 +1159,9 @@ private static boolean isComplianceJava11OrHigher(IJavaProject javaProject) {
 @Override
 public IBinaryType getElementInfo() throws JavaModelException {
 	return (IBinaryType) super.getElementInfo();
+}
+@Override
+public boolean isImplicitlyDeclared() throws JavaModelException {
+	return (this.getFlags() & ExtraCompilerModifiers.AccUnnamed) != 0;
 }
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceType.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.internal.codeassist.CompletionEngine;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
+import org.eclipse.jdt.internal.compiler.lookup.ExtraCompilerModifiers;
 import org.eclipse.jdt.internal.core.hierarchy.TypeHierarchy;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
 import org.eclipse.jdt.internal.core.util.Messages;
@@ -1012,5 +1013,9 @@ protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean 
 @Override
 public boolean isLambda() {
 	return false;
+}
+@Override
+public boolean isImplicitlyDeclared() throws JavaModelException {
+	return (this.getFlags() & ExtraCompilerModifiers.AccUnnamed) != 0;
 }
 }

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -17,7 +17,7 @@
     <version>4.31.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>3.37.0-SNAPSHOT</version>
+  <version>3.38.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
Using the `<unnamed_class$MyUnnamedClass>` name is bad, because then the generated `.class` file is invalid and can't be run.

Current blocking problems:
- [x] At least one failing test
- [x] Need some method to determine if an `IType` is unnamed. In https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3077 I am using the type name, but this will no longer work after this PR