### PR TITLE
Fix some tests when types are resolved

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.core.tests.model;
 
 import java.io.IOException;
+import java.util.Set;
 
 import junit.framework.Test;
 
@@ -975,10 +976,9 @@ public void testLocalVarIsStructureKnown() throws JavaModelException {
  */
 public void testLocalVarTypeSignature1() throws JavaModelException {
 	ILocalVariable localVar = getLocalVariable("/Resolve/src/ResolveLocalName.java", "var1 = new Object();", "var1");
-	assertEquals(
-		"Unexpected type signature",
-		"QObject;",
-		localVar.getTypeSignature());
+	assertTrue("Unexpected type signature",
+		Set.of("QObject;", "Ljava.lang.Object;").contains(
+		localVar.getTypeSignature()));
 }
 /*
  * Resolve a local reference and ensure its type signature is correct.
@@ -1466,10 +1466,9 @@ public void testDuplicateLocals1() throws JavaModelException {
 			elements
 		);
 
-	assertEquals(
-			"Unexpected type",
-			"QTestString;",
-			((ILocalVariable)elements[0]).getTypeSignature());
+	assertTrue("Unexpected type",
+		Set.of("QTestString;", "Ltest.TestString;)").contains(
+		((ILocalVariable)elements[0]).getTypeSignature()));
 	assertFalse(((ILocalVariable)elements[0]).isParameter());
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=144858
@@ -1509,10 +1508,9 @@ public void testDuplicateLocals2() throws JavaModelException {
 			elements
 		);
 
-	assertEquals(
-			"Unexpected type",
-			"QTestException;",
-			((ILocalVariable)elements[0]).getTypeSignature());
+	assertTrue("Unexpected type",
+		Set.of("QTestException;", "Ltest.TestException;").contains(
+		((ILocalVariable)elements[0]).getTypeSignature()));
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=144858
 public void testDuplicateLocals3() throws JavaModelException {
@@ -1548,10 +1546,9 @@ public void testDuplicateLocals3() throws JavaModelException {
 			elements
 		);
 
-	assertEquals(
-			"Unexpected type",
-			"QTestString;",
-			((ILocalVariable)elements[0]).getTypeSignature());
+	assertTrue("Unexpected type",
+		Set.of("QTestString;", "Ltest.TestString;").contains(
+			((ILocalVariable)elements[0]).getTypeSignature()));
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=144858
 public void testDuplicateLocals4() throws JavaModelException {
@@ -1589,10 +1586,9 @@ public void testDuplicateLocals4() throws JavaModelException {
 			elements
 		);
 
-	assertEquals(
-			"Unexpected type",
-			"QTestString;",
-			((ILocalVariable)elements[0]).getTypeSignature());
+	assertTrue("Unexpected type",
+		Set.of("QTestString;", "Ltest.TestString;").contains(
+		((ILocalVariable)elements[0]).getTypeSignature()));
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=144858
 public void testDuplicateLocals5() throws JavaModelException {
@@ -1630,10 +1626,9 @@ public void testDuplicateLocals5() throws JavaModelException {
 			elements
 		);
 
-	assertEquals(
-			"Unexpected type",
-			"QTestString;",
-			((ILocalVariable)elements[0]).getTypeSignature());
+	assertTrue("Unexpected type",
+		Set.of("QTestString;", "Ltest.TestString;").contains(
+		((ILocalVariable)elements[0]).getTypeSignature()));
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=165662
 public void testDuplicateLocalsType1() throws JavaModelException {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeResolveTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeResolveTests.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.core.tests.model;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -1399,7 +1400,9 @@ public void test531046g() throws CoreException, IOException {
 		IJavaElement[] elements = unit.codeSelect(source.lastIndexOf(select), select.length());
 		assertEquals("should not be empty", 1, elements.length);
 		ILocalVariable variable = (ILocalVariable) elements[0];
-		assertEquals("incorrect type", "&QCharSequence;:QComparable<QString;>;", variable.getTypeSignature());
+		assertTrue("incorrect type",
+			Set.of("&QCharSequence;:QComparable<QString;>;", "&Ljava.lang.CharSequence;:Ljava.lang.Comparable<Ljava.lang.String;>;").contains(
+			variable.getTypeSignature()));
 	} finally {
 		deleteProject("P");
 	}
@@ -1424,7 +1427,9 @@ public void test531046h() throws CoreException, IOException {
 		IJavaElement[] elements = unit.codeSelect(source.lastIndexOf(select), select.length());
 		assertEquals("should not be empty", 1, elements.length);
 		ILocalVariable variable = (ILocalVariable) elements[0];
-		assertEquals("incorrect type", "&QCharSequence;:QComparable<QString;>;", variable.getTypeSignature());
+		assertTrue("incorrect type",
+			Set.of("&QCharSequence;:QComparable<QString;>;", "&Ljava.lang.CharSequence;:Ljava.lang.Comparable<Ljava.lang.String;>;").contains(
+			variable.getTypeSignature()));
 	} finally {
 		deleteProject("P");
 	}


### PR DESCRIPTION
Using bindings, the types are resolved. Allow tests to pass with resolved types as well.