### PR TITLE
Allow parsing document with just identifier

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -144,6 +144,7 @@ class JavacConverter {
 		javacCompilationUnit.getImports().stream().map(jc -> convert(jc)).forEach(res.imports()::add);
 		javacCompilationUnit.getTypeDecls().stream()
 			.map(n -> convertBodyDeclaration(n, res))
+			.filter(entry -> entry != null)
 			.forEach(res.types()::add);
 		res.accept(new FixPositions());
 	}
@@ -418,6 +419,9 @@ class JavacConverter {
 			commonSettings(res, tree);
 			res.setBody(convertBlock(block));
 			return res;
+		}
+		if (tree instanceof JCErroneous) {
+			return null;
 		}
 		throw new UnsupportedOperationException("Unsupported " + tree + " of type" + tree.getClass());
 	}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -144,7 +144,7 @@ class JavacConverter {
 		javacCompilationUnit.getImports().stream().map(jc -> convert(jc)).forEach(res.imports()::add);
 		javacCompilationUnit.getTypeDecls().stream()
 			.map(n -> convertBodyDeclaration(n, res))
-			.filter(entry -> entry != null)
+			.filter(Objects::nonNull)
 			.forEach(res.types()::add);
 		res.accept(new FixPositions());
 	}


### PR DESCRIPTION
- Discard erroneous body declarations