### PR TITLE
Implement some methods in JavacMethodBinding

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -28,6 +28,7 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.PackageSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.comp.AttrContext;
 import com.sun.tools.javac.comp.Env;
 import com.sun.tools.javac.comp.Modules;
@@ -250,6 +251,10 @@ public class JavacBindingResolver extends BindingResolver {
 		return this.converter.domToJavac.get(expr) instanceof JCExpression jcExpr ?
 			new JavacTypeBinding(jcExpr.type, this) :
 			null;
+	}
+
+	public Types getTypes() {
+		return Types.instance(this.context);
 	}
 
 }

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
@@ -259,8 +259,10 @@ public class JavacMethodBinding implements IMethodBinding {
 
 	@Override
 	public boolean isSubsignature(IMethodBinding otherMethod) {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'isSubsignature'");
+		if (otherMethod instanceof JavacMethodBinding otherJavacMethod) {
+			return resolver.getTypes().isSubSignature(this.methodSymbol.asType(), otherJavacMethod.methodSymbol.asType());
+		}
+		return false;
 	}
 
 	@Override
@@ -283,8 +285,9 @@ public class JavacMethodBinding implements IMethodBinding {
 
 	@Override
 	public boolean isSyntheticRecordMethod() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'isSyntheticRecordMethod'");
+		return !this.methodSymbol.isStatic()
+				&& (this.methodSymbol.flags() & Flags.SYNTHETIC) != 0
+				&& (this.methodSymbol.type.tsym.flags() & Flags.RECORD) != 0;
 	}
 
 	@Override


### PR DESCRIPTION
- Adds jdk.compiler/com.sun.tools.javac.model as a dependency, so you will need to add a new export for the package in the launch configuration

Closes #176 