### PR TITLE
Add Java 23 constants

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AST.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AST.java
@@ -470,6 +470,21 @@ public final class AST {
 	 */
 	public static final int JLS22 = 22;
 	/**
+	 * Constant for indicating the AST API that handles JLS22.
+	 * <p>
+	 * This API is capable of handling all constructs in the
+	 * Java language as described in the Java Language
+	 * Specification, Java SE 23 Edition (JLS23).
+	 * JLS23 is a superset of all earlier versions of the
+	 * Java language, and the JLS23 API can be used to manipulate
+	 * programs written in all versions of the Java language
+	 * up to and including Java SE 23(aka JDK 23).
+	 * </p>
+	 *
+	 * @since 3.38
+	 */
+	public static final int JLS23 = 23;
+	/**
 	 * Internal synonym for {@link #JLS15}. Use to alleviate
 	 * deprecation warnings once JLS15 is deprecated
 	 */
@@ -509,6 +524,11 @@ public final class AST {
 	 * deprecation warnings once JLS21 is deprecated
 	 */
 	static final int JLS22_INTERNAL = JLS22;
+	/**
+	 * Internal synonym for {@link #JLS22}. Use to alleviate
+	 * deprecation warnings once JLS21 is deprecated
+	 */
+	static final int JLS23_INTERNAL = JLS23;
 	/**
 	 * Internal property for latest supported JLS level
 	 * This provides the latest JLS level.
@@ -1260,6 +1280,7 @@ public final class AST {
         t.put(JavaCore.VERSION_20, ClassFileConstants.JDK20);
         t.put(JavaCore.VERSION_21, ClassFileConstants.JDK21);
         t.put(JavaCore.VERSION_22, ClassFileConstants.JDK22);
+        t.put(JavaCore.VERSION_23, ClassFileConstants.JDK23);
         return Collections.unmodifiableMap(t);
 	}
 	private static Map<String, Integer> getApiLevelMapTable() {
@@ -1286,6 +1307,7 @@ public final class AST {
         t.put(JavaCore.VERSION_20, JLS20_INTERNAL);
         t.put(JavaCore.VERSION_21, JLS21_INTERNAL);
         t.put(JavaCore.VERSION_22, JLS22_INTERNAL);
+        t.put(JavaCore.VERSION_23, JLS23_INTERNAL);
         return Collections.unmodifiableMap(t);
 	}
 	/**

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTNode.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTNode.java
@@ -2613,6 +2613,21 @@ public abstract class ASTNode {
 		}
 	}
 	/**
+ 	 * Checks that this AST operation is only used when
+     * building JLS23 level ASTs.
+     * <p>
+     * Use this method to prevent access to new properties available only in JLS23.
+     * </p>
+     *
+	 * @exception UnsupportedOperationException if this operation is not used in JLS23
+	 * @since 3.38
+	 */
+	final void supportedOnlyIn23() {
+		if (this.ast.apiLevel < AST.JLS23_INTERNAL) {
+			throw new UnsupportedOperationException("Operation only supported in JLS23 AST"); //$NON-NLS-1$
+		}
+	}
+	/**
      * Checks that this AST operation is not used when
      * building JLS20 level ASTs.
      * <p>


### PR DESCRIPTION
Proposing to add them to this branch as being able to get Java 23 AST without ecj being able to do so and javac not being in master looks wrong.