### PR TITLE
Set source and target to 1.8 if it's below 1.8

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacUtils.java
@@ -69,11 +69,21 @@ public class JavacUtils {
 		} else {
 			String source = compilerOptions.get(CompilerOptions.OPTION_Source);
 			if (source != null && !source.isEmpty()) {
-				options.put(Option.SOURCE, source);
+				if (source.indexOf("1.") != -1 && source.indexOf("1.8") == -1 || source.indexOf(".") == -1 && Integer.parseInt(source) < 8) {
+					ILog.get().warn("Unsupported source level: " + source + ", using 1.8 instead");
+					options.put(Option.SOURCE, "1.8");
+				} else {
+					options.put(Option.SOURCE, source);
+				}
 			}
 			String target = compilerOptions.get(CompilerOptions.OPTION_TargetPlatform);
 			if (target != null && !target.isEmpty()) {
-				options.put(Option.TARGET, target);
+				if (target.indexOf("1.") != -1 && target.indexOf("1.8") == -1 || target.indexOf(".") == -1 && Integer.parseInt(target) < 8) {
+					ILog.get().warn("Unsupported target level: " + target + ", using 1.8 instead");
+					options.put(Option.TARGET, "1.8");
+				} else {
+					options.put(Option.TARGET, target);
+				}
 			}
 		}
 		options.put(Option.XLINT_CUSTOM, "all"); // TODO refine according to compilerOptions


### PR DESCRIPTION
- Log a warning when this is used

The main reason I'm making this change is that many of the tests for AST conversion target 1.4 . By using 1.8 instead of failing in these cases, we can run these test cases properly. Many of these test cases reveal bugs in our AST converter that we need to address that are unrelated to source or target level.

I think it's worthwhile to increase the source level, because this means the user is able to use IDE features before reconfiguring the project to use Java 8. However, if people think it's a bad idea to enable this in the IDE, then I can use an environment variable to enable this, so that it's only enabled when running the AST conversion tests.