### PR TITLE
Fix wrong rawText being used when parsing multiple files

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
@@ -311,7 +311,7 @@ class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 
 
 		JCCompilationUnit javacCompilationUnit = null;
-		JavacTask task = ((JavacTool)compiler).getTask(null, fileManager, null /* already added to context */, List.of() /* already set in options */, List.of() /* already set */, filesToUnits.keySet(), context);
+		JavacTask task = ((JavacTool)compiler).getTask(null, fileManager, null /* already added to context */, List.of() /* already set in options */, List.of() /* already set */, fileObjects, context);
 		{
 			// don't know yet a better way to ensure those necessary flags get configured
 			var javac = com.sun.tools.javac.main.JavaCompiler.instance(context);


### PR DESCRIPTION
My resolve change accessed an entry set in order to access some JavaFileObjects, however this set doesn't necessarily have the same order as the array of CompilationUnits I was reading from, which caused the wrong rawText to be passed in during conversion