### PR TITLE
Fix type bindings for secondary types

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -17,6 +17,7 @@ import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeKind;
 
 import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.IAnnotationBinding;
@@ -99,7 +100,7 @@ public class JavacTypeBinding implements ITypeBinding {
 		}
 		if (this.typeSymbol instanceof final ClassSymbol classSymbol) {
 			try {
-				return this.resolver.javaProject.findType(classSymbol.className());
+				return this.resolver.javaProject.findType(classSymbol.className(), new NullProgressMonitor());
 			} catch (JavaModelException ex) {
 				ILog.get().error(ex.getMessage(), ex);
 			}


### PR DESCRIPTION
Turns out the issue was completely unrelated to static blocks, it was with resolving secondary types.

This PR uses a slightly different method that includes all secondary types in the type search. There might be a better way to do this, where we find the primary type then get the secondary type using the `ICompilationUnit`. However, I wasn't able to access the `PrimaryType$SecondaryType` style name from the javac symbol, so this is the best I have for right now.

Fixes #361