### PR TITLE
Fix offset issue in the DOMCompletionEngine context

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionContext.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionContext.java
@@ -20,13 +20,17 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.dom.IBinding;
 
 class DOMCompletionContext extends CompletionContext {
-    private int offset;
-    private char[] token;
-    private IJavaElement enclosingElement;
-    private Collection<? extends IBinding> visibleBindings;
+    private final int offset;
+    private final char[] token;
+    private final IJavaElement enclosingElement;
+    private final Collection<? extends IBinding> visibleBindings;
 
-    DOMCompletionContext(int offset) {
+    DOMCompletionContext(int offset, char[] token, IJavaElement enclosingElement,
+            Collection<? extends IBinding> bindings) {
         this.offset = offset;
+        this.enclosingElement = enclosingElement;
+        this.visibleBindings = bindings;
+        this.token = token;
     }
 
     @Override
@@ -39,17 +43,9 @@ class DOMCompletionContext extends CompletionContext {
         return this.token;
     }
 
-    public void setToken(char[] t) {
-        this.token = t;
-    }
-
     @Override
     public IJavaElement getEnclosingElement() {
         return this.enclosingElement;
-    }
-
-    public void setEnclosingElement(IJavaElement enclosingElement) {
-        this.enclosingElement = enclosingElement;
     }
 
     @Override
@@ -60,9 +56,5 @@ class DOMCompletionContext extends CompletionContext {
 
         // todo: calculate based on visible elements
         return new IJavaElement[0];
-    }
-
-    public void setVisibleBindings(Collection<? extends IBinding> bindings) {
-        this.visibleBindings = bindings;
     }
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionContext.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionContext.java
@@ -13,13 +13,17 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.codeassist;
 
+import java.util.Collection;
+
 import org.eclipse.jdt.core.CompletionContext;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.dom.IBinding;
 
 class DOMCompletionContext extends CompletionContext {
     private int offset;
     private char[] token;
     private IJavaElement enclosingElement;
+    private Collection<? extends IBinding> visibleBindings;
 
     DOMCompletionContext(int offset) {
         this.offset = offset;
@@ -46,5 +50,19 @@ class DOMCompletionContext extends CompletionContext {
 
     public void setEnclosingElement(IJavaElement enclosingElement) {
         this.enclosingElement = enclosingElement;
+    }
+
+    @Override
+    public IJavaElement[] getVisibleElements(String typeSignature) {
+        if (this.visibleBindings == null || this.visibleBindings.isEmpty()) {
+            return new IJavaElement[0];
+        }
+
+        // todo: calculate based on visible elements
+        return new IJavaElement[0];
+    }
+
+    public void setVisibleBindings(Collection<? extends IBinding> bindings) {
+        this.visibleBindings = bindings;
     }
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionContext.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionContext.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *     Gayan Perera - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.codeassist;
+
+import org.eclipse.jdt.core.CompletionContext;
+import org.eclipse.jdt.core.IJavaElement;
+
+class DOMCompletionContext extends CompletionContext {
+    private int offset;
+    private char[] token;
+    private IJavaElement enclosingElement;
+
+    DOMCompletionContext(int offset) {
+        this.offset = offset;
+    }
+
+    @Override
+    public int getOffset() {
+        return this.offset;
+    }
+
+    @Override
+    public char[] getToken() {
+        return this.token;
+    }
+
+    public void setToken(char[] t) {
+        this.token = t;
+    }
+
+    @Override
+    public IJavaElement getEnclosingElement() {
+        return this.enclosingElement;
+    }
+
+    public void setEnclosingElement(IJavaElement enclosingElement) {
+        this.enclosingElement = enclosingElement;
+    }
+}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
@@ -34,6 +34,7 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
@@ -233,8 +234,12 @@ public class DOMCompletionEngine implements Runnable {
 		}
 		if (context instanceof MethodInvocation invocation) {
 			if (this.offset <= invocation.getName().getStartPosition() + invocation.getName().getLength()) {
+				Expression expression = invocation.getExpression();
+				if (expression == null) {
+					return;
+				}
 				// complete name
-				ITypeBinding type = invocation.getExpression().resolveTypeBinding();
+				ITypeBinding type = expression.resolveTypeBinding();
 				processMembers(type, scope);
 				scope.stream()
 				.filter(binding -> this.pattern.matchesName(this.prefix.toCharArray(), binding.getName().toCharArray()))

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
@@ -118,7 +118,7 @@ public class ExpectedTypes {
 				this.expectedTypes.add(binding);
 				this.expectedTypesFilters = Set.of(TypeFilter.SUBTYPE, TypeFilter.SUPERTYPE);
 			}
-		} else if(parent instanceof MethodInvocation messageSend) {
+		} else if (parent instanceof MethodInvocation messageSend && messageSend.getExpression() != null) {
 			final ITypeBinding initialBinding = messageSend.getExpression().resolveTypeBinding();
 			ITypeBinding currentBinding = initialBinding; // messageSend.actualReceiverType
 			boolean isStatic = messageSend.getExpression() instanceof Name name && name.resolveBinding() instanceof ITypeBinding;


### PR DESCRIPTION
This small PR tries to fix the offset issue which will fail when completion items are created by jdtls. A CompletionContext subclass is introduced for DOMCompletionEngine. Possibly future improvements and code cleanup needs when DOMCompletionEngine evolves.