### PR TITLE
[javac] fix NPE while computing quickfixes

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
@@ -302,7 +302,6 @@ class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 			var fileObject = fileManager.getJavaFileObject(sourceUnitPath);
 			fileManager.cache(fileObject, CharBuffer.wrap(sourceUnit.getContents()));
 			AST ast = createAST(compilerOptions, apiLevel, context);
-			ast.setDefaultNodeFlag(ASTNode.ORIGINAL);
 			CompilationUnit res = ast.newCompilationUnit();
 			result.put(sourceUnit, res);
 			filesToUnits.put(fileObject, res);
@@ -337,6 +336,8 @@ class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 				}
 				CompilationUnit res = result.get(sourceUnits[i]);
 				AST ast = res.ast;
+				int savedDefaultNodeFlag = ast.getDefaultNodeFlag();
+				ast.setDefaultNodeFlag(ASTNode.ORIGINAL);
 				JavacConverter converter = new JavacConverter(ast, javacCompilationUnit, context, rawText);
 				converter.populateCompilationUnit(res, javacCompilationUnit);
 				attachComments(res, context, fileObjects.get(i), converter, compilerOptions);
@@ -356,6 +357,7 @@ class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 				ast.setBindingResolver(new JavacBindingResolver(javaProject, task, context, converter));
 				//
 				ast.setOriginalModificationCount(ast.modificationCount()); // "un-dirty" AST so Rewrite can process it
+				ast.setDefaultNodeFlag(savedDefaultNodeFlag);
 			}
 		} catch (IOException ex) {
 			ILog.get().error(ex.getMessage(), ex);


### PR DESCRIPTION
The root cause was managing a flag properly. This flag indicates which nodes are part of the original AST, and which are added as part of the rewrite.

Fixes #323