### PR TITLE
[javac] fix syntax highlighting of parameters

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -814,6 +814,9 @@ class JavacConverter {
 		SingleVariableDeclaration res = this.ast.newSingleVariableDeclaration();
 		commonSettings(res, javac);
 		if (convertName(javac.getName()) instanceof SimpleName simpleName) {
+			int endPos = javac.getEndPosition(this.javacCompilationUnit.endPositions);
+			int length = simpleName.toString().length();
+			simpleName.setSourceRange(endPos - length, length);
 			res.setName(simpleName);
 		}
 		if( this.ast.apiLevel != AST.JLS2_INTERNAL) {


### PR DESCRIPTION
- Set the source range of the parameter name

Fixes #379