### PR TITLE
fill in record components in record declaration

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -553,6 +553,12 @@ class JavacConverter {
 //				annotationTypeMemberDeclaration2.setDefault(convert(memberValue));
 //			}
 
+		} else if (res instanceof RecordDeclaration recordDecl) {
+			for (JCTree node : javacClassDecl.getMembers()) {
+				if (node instanceof JCVariableDecl vd) {
+					recordDecl.recordComponents().add(convertVariableDeclaration(vd));
+				}
+			}
 		}
 		// TODO Javadoc
 		return res;


### PR DESCRIPTION
Process the record type declaration members and fill in the record components from the variable declaration into the jdt DOM.

```
package com.example;

public record Person(String name, int age) {
    
}
```

The record declaration should now have record components and syntax highlighting and variable name completion should work for record components also