### PR TITLE
Conversion fixes and a StackOverflow fix

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -1612,10 +1612,20 @@ class JavacConverter {
 			}
 		}
 		if (value instanceof String string) {
-			StringLiteral res = this.ast.newStringLiteral();
-			commonSettings(res, literal);
-			res.setLiteralValue(string);  // TODO: we want the token here
-			return res;
+			if (this.rawText.charAt(literal.pos) == '"'
+					&& this.rawText.charAt(literal.pos + 1) == '"'
+					&& this.rawText.charAt(literal.pos + 2) == '"') {
+				TextBlock res = this.ast.newTextBlock();
+				commonSettings(res, literal);
+				String rawValue = this.rawText.substring(literal.pos, literal.getEndPosition(this.javacCompilationUnit.endPositions));
+				res.internalSetEscapedValue(rawValue, string);
+				return res;
+			} else {
+				StringLiteral res = this.ast.newStringLiteral();
+				commonSettings(res, literal);
+				res.setLiteralValue(string);  // TODO: we want the token here
+				return res;
+			}
 		}
 		if (value instanceof Boolean string) {
 			BooleanLiteral res = this.ast.newBooleanLiteral(string.booleanValue());

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -472,8 +472,10 @@ class JavacConverter {
 					javacClassDecl.getPermitsClause().stream()
 						.map(this::convertToType)
 						.forEach(typeDeclaration.permittedTypes()::add);
-					int sealedOffset = this.rawText.substring(javacClassDecl.pos).indexOf("permits") + javacClassDecl.pos;
-					typeDeclaration.setRestrictedIdentifierStartPosition(sealedOffset);
+					if (!javacClassDecl.getPermitsClause().isEmpty()) {
+						int permitsOffset = this.rawText.substring(javacClassDecl.pos).indexOf("permits") + javacClassDecl.pos;
+						typeDeclaration.setRestrictedIdentifierStartPosition(permitsOffset);
+					}
 				}
 			}
 			if (javacClassDecl.getMembers() != null) {

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -371,7 +371,7 @@ class JavacConverter {
 				n = this.ast.newSimpleName("NOT_SET");
 			}
 			commonSettings(n, fieldAccess);
-			
+
 			Name qualifier = toName(faExpression);
 			QualifiedName res = this.ast.newQualifiedName(qualifier, n);
 			commonSettings(res, fieldAccess.getExpression());
@@ -472,6 +472,8 @@ class JavacConverter {
 					javacClassDecl.getPermitsClause().stream()
 						.map(this::convertToType)
 						.forEach(typeDeclaration.permittedTypes()::add);
+					int sealedOffset = this.rawText.substring(javacClassDecl.pos).indexOf("permits") + javacClassDecl.pos;
+					typeDeclaration.setRestrictedIdentifierStartPosition(sealedOffset);
 				}
 			}
 			if (javacClassDecl.getMembers() != null) {

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -128,7 +128,7 @@ public class JavacProblemConverter {
 			DiagnosticSource source = jcDiagnostic.getDiagnosticSource();
 			JavaFileObject fileObject = source.getFile();
 			CharSequence charContent = fileObject.getCharContent(true);
-			ScannerFactory scannerFactory = ScannerFactory.instance(context);
+			ScannerFactory scannerFactory = ScannerFactory.instance(new Context());
 			Scanner javacScanner = scannerFactory.newScanner(charContent, true);
 			Token t = javacScanner.token();
 			while (t != null && t.kind != TokenKind.EOF && t.endPos <= preferedOffset) {


### PR DESCRIPTION
- Set offset for `permits` keyword in `TypeDeclaration`
- Fix conversion for `TextBlock`
- Fix a StackOverflow caused by adjusting error ranges using tokens. Since the `Context` object was reused when acquiring the scanner, using the scanner caused the file to be reparsed, which retriggered validation, causing infinite recursion.