### PR TITLE
Avoid errors related to source versions vs preview

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileConstants.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileConstants.java
@@ -142,7 +142,8 @@ public interface ClassFileConstants {
 	int MAJOR_VERSION_23 = 67;
 
 	int MAJOR_VERSION_0 = 44;
-	int MAJOR_LATEST_VERSION = MAJOR_VERSION_23;
+	// Latest version supported by ECJ (not necessarily latest known Java version)
+	int MAJOR_LATEST_VERSION = MAJOR_VERSION_22;
 
 	int MINOR_VERSION_0 = 0;
 	int MINOR_VERSION_1 = 1;
@@ -177,6 +178,10 @@ public interface ClassFileConstants {
 	long JDK22 = ((long)ClassFileConstants.MAJOR_VERSION_22 << 16) + ClassFileConstants.MINOR_VERSION_0;
 	long JDK23 = ((long)ClassFileConstants.MAJOR_VERSION_23 << 16) + ClassFileConstants.MINOR_VERSION_0;
 
+	/**
+	 *
+	 * @return The latest JDK level supported by ECJ (can be different from the latest known JDK level)
+	 */
 	public static long getLatestJDKLevel() {
 		return ((long)ClassFileConstants.MAJOR_LATEST_VERSION << 16) + ClassFileConstants.MINOR_VERSION_0;
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
@@ -541,7 +541,9 @@ public org.eclipse.jdt.core.dom.CompilationUnit getOrBuildAST(WorkingCopyOwner w
 	if (this.ast != null && storeAST) {
 		return this.ast;
 	}
-	ASTParser parser = ASTParser.newParser(AST.getJLSLatest()); // TODO use Java project info
+	Map<String, String> options = getOptions(true);
+	int jlsLevel = Integer.parseInt(options.getOrDefault(JavaCore.COMPILER_SOURCE, Integer.toString(AST.getJLSLatest())));
+	ASTParser parser = ASTParser.newParser(jlsLevel);
 	parser.setWorkingCopyOwner(workingCopyOwner);
 	parser.setSource(this);
 	// greedily enable everything assuming the AST will be used extensively for edition


### PR DESCRIPTION
* Don't change the ClassFileConstants.MAJOR_LATEST_VERSION until it's supported by ECJ
* Read more level from project settings

What seems important is that the new versions get defined and mapped in AST.jdkLevelMap and AST.apiLevelMap