### PR TITLE
Prevent StackOverflow in 'add missing methods'

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -349,6 +349,9 @@ class JavacConverter {
 					endPos = start + javac.toString().length();
 				}
 				int length = endPos - start;
+				if (start + Math.max(0, length) > this.rawText.length()) {
+					length = this.rawText.length() - start;
+				}
 				res.setSourceRange(start, Math.max(0, length));
 			}
 			this.domToJavac.put(res, javac);
@@ -675,7 +678,7 @@ class JavacConverter {
 		}
 		return null;
 	}
-	
+
 	private String getMethodDeclName(JCMethodDecl javac, ASTNode parent, boolean records) {
 		String name = javac.getName().toString();
 		boolean javacIsConstructor = Objects.equals(javac.getName(), Names.instance(this.context).init);
@@ -2701,7 +2704,7 @@ class JavacConverter {
 		public boolean visit(Modifier modifier) {
 			int parentStart = modifier.getParent().getStartPosition();
 			int relativeStart = this.contents.substring(parentStart, parentStart + modifier.getParent().getLength()).indexOf(modifier.getKeyword().toString());
-			if (relativeStart >= 0) {
+			if (relativeStart >= 0 && relativeStart < modifier.getParent().getLength()) {
 				modifier.setSourceRange(parentStart + relativeStart, modifier.getKeyword().toString().length());
 			} else {
 				ILog.get().warn("Couldn't compute position of " + modifier);

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -592,8 +592,9 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 
 	@Override
 	public boolean isClass() {
+		// records count as classes, so they are not excluded here
 		return this.typeSymbol instanceof final ClassSymbol classSymbol
-				&& !(classSymbol.isEnum() || classSymbol.isRecord() || classSymbol.isInterface());
+				&& !(classSymbol.isEnum() || classSymbol.isInterface());
 	}
 
 	@Override
@@ -634,7 +635,10 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 
 	@Override
 	public boolean isMember() {
-		return this.typeSymbol.owner instanceof ClassSymbol;
+		if (isClass() || isInterface() || isEnum()) {
+			return this.typeSymbol.owner instanceof ClassSymbol;
+		}
+		return false;
 	}
 
 	@Override
@@ -692,7 +696,8 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 	public boolean isWildcardType() {
 		return this.type instanceof WildcardType;
 	}
-	
+
+	@Override
 	public IModuleBinding getModule() {
 		Symbol o = this.type.tsym.owner;
 		if( o instanceof PackageSymbol ps) {


### PR DESCRIPTION
- If you extend a type with type parameters, then using the quickfix to add the missing methods used to cause a StackOverflow
- The quickfix doesn't work, this just prevents the StackOverflow. We still need to improve the handing of type parameters vs type arguments.
- I've included an unrelated fix for implicitly declared class ranges