### PR TITLE
Fix isRecovered for annotation bindings

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -772,9 +772,15 @@ public class JavacBindingResolver extends BindingResolver {
 	@Override
 	IAnnotationBinding resolveAnnotation(Annotation annotation) {
 		resolve();
+		IBinding recipient = null;
+		if (annotation.getParent() instanceof AnnotatableType annotatable) {
+			recipient = annotatable.resolveBinding();
+		} else if (annotation.getParent() instanceof FieldDeclaration fieldDeclaration) {
+			recipient = ((VariableDeclarationFragment)fieldDeclaration.fragments().get(0)).resolveBinding();
+		}
 		var javac = this.converter.domToJavac.get(annotation);
 		if (javac instanceof JCAnnotation jcAnnotation) {
-			return this.bindings.getAnnotationBinding(jcAnnotation.attribute, null);
+			return this.bindings.getAnnotationBinding(jcAnnotation.attribute, recipient);
 		}
 		return null;
 	}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacAnnotationBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacAnnotationBinding.java
@@ -28,7 +28,6 @@ public abstract class JavacAnnotationBinding implements IAnnotationBinding {
 	private final JavacBindingResolver resolver;
 	private final Compound annotation;
 
-	private transient String key;
 	private final IBinding recipient;
 
 	public JavacAnnotationBinding(Compound ann, JavacBindingResolver resolver, IBinding recipient) {
@@ -71,7 +70,7 @@ public abstract class JavacAnnotationBinding implements IAnnotationBinding {
 
 	@Override
 	public boolean isRecovered() {
-		throw new UnsupportedOperationException("Unimplemented method 'isRecovered'");
+		return getAnnotationType().isRecovered();
 	}
 
 	@Override


### PR DESCRIPTION
- Small bug fix related to getKey for annotation bindings where the parent is sometimes not set correctly