### PR TITLE
Prevent NPE in JavacMethodBinding.findJavaElement()

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
@@ -168,7 +168,7 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 									Signature.createTypeSignature(resolveTypeName(t, true), true))
 							.toArray(String[]::new);
 					IMethod[] methods = currentType.findMethods(currentType.getMethod(getName(), parametersResolved));
-					if (methods.length > 0) {
+					if (methods != null && methods.length > 0) {
 						return methods[0];
 					}
 					var parametersNotResolved = this.methodSymbol.params().stream()
@@ -178,7 +178,7 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 									Signature.createTypeSignature(resolveTypeName(t, false), false))
 							.toArray(String[]::new);
 					methods = currentType.findMethods(currentType.getMethod(getName(), parametersNotResolved));
-					if (methods.length > 0) {
+					if (methods != null && methods.length > 0) {
 						return methods[0];
 					}
 				}


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator/issues/530