### PR TITLE
javac cannot downcompile newer features, so increase the target version

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacUtils.java
@@ -120,6 +120,10 @@ public class JavacUtils {
 					ILog.get().warn("Unsupported target level: " + target + ", using 8 instead");
 					options.put(Option.TARGET, "8");
 				} else {
+					if (Integer.parseInt(target) < Integer.parseInt(source)) {
+						ILog.get().warn("javac requires the source version to be less than or equal to the target version. Targetting " + source + " instead");
+						target = source;
+					}
 					options.put(Option.TARGET, target);
 				}
 			}


### PR DESCRIPTION
javac complains if the source is higher than the target version, because it can't downcompile all the new features. Increase the target version in this case.