### PR TITLE
Fix the "remove abstract keywiord" and "remove body" quickfixes

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -869,12 +869,8 @@ class JavacConverter {
 				boolean notAllowed = (isAbstractOrNative || (isInterface && (isJlsBelow8 || (modFlags & flagsToCheckForAboveJLS8) == 0)));
 				if (notAllowed) {
 					res.setFlags(res.getFlags() | ASTNode.MALFORMED);
-					Block b1 = this.ast.newBlock();
-					commonSettings(b1, javac);
-					res.setBody(b1);
-				} else {
-					res.setBody(b);
 				}
+				res.setBody(b);
 			}
 
 			if( (b.getFlags() & ASTNode.MALFORMED) > 0 ) {
@@ -1044,7 +1040,7 @@ class JavacConverter {
 			} else {
 				res.internalSetModifiers(getJLS2ModifiersFlags(javac.mods));
 			}
-			
+
 			Type resType = null;
 			int count = fragment.getExtraDimensions();
 			if( count > 0 ) {
@@ -1073,7 +1069,7 @@ class JavacConverter {
 					return null;
 				}
 			}
-			
+
 			return res;
 		}
 	}
@@ -1634,7 +1630,7 @@ class JavacConverter {
 		}
 		return null;
 	}
-	
+
 	private Expression handleInfixExpression(JCBinary binary, JCExpression javac) {
 		List<JCExpression> conseq = consecutiveInfixExpressionsWithEqualOps(binary, binary.getTag());
 		if( conseq != null && conseq.size() > 2 ) {
@@ -1643,7 +1639,7 @@ class JavacConverter {
 
 		InfixExpression res = this.ast.newInfixExpression();
 		commonSettings(res, javac);
-		
+
 		Expression left = convertExpression(binary.getLeftOperand());
 		if (left != null) {
 			res.setLeftOperand(left);
@@ -1661,7 +1657,7 @@ class JavacConverter {
 
 		InfixExpression res = this.ast.newInfixExpression();
 		commonSettings(res, javac);
-		
+
 		Expression left = convertExpression(conseq.get(0));
 		if (left != null) {
 			res.setLeftOperand(left);
@@ -1673,11 +1669,11 @@ class JavacConverter {
 		for( int i = 2; i < conseq.size(); i++ ) {
 			res.extendedOperands().add(convertExpression(conseq.get(i)));
 		}
-		
+
 		res.setOperator(binaryTagToInfixOperator(binary.getTag()));
 		return res;
 	}
-	
+
 	private InfixExpression.Operator binaryTagToInfixOperator(Tag t) {
 		return switch (t) {
 			case OR -> InfixExpression.Operator.CONDITIONAL_OR;
@@ -1702,7 +1698,7 @@ class JavacConverter {
 			default -> null;
 		};
 	}
-	
+
 
 	/**
 	 * precondition: you've checked all the segments are identifier that can be used in a qualified name
@@ -1871,7 +1867,7 @@ class JavacConverter {
 		}
 		return elem;
 	}
-	
+
 	private int countDimensions(JCTree tree) {
 		JCTree elem = tree;
 		int count = 0;
@@ -2610,7 +2606,7 @@ class JavacConverter {
 					int startPos = jcArrayType.getStartPosition();
 					try {
 						String raw = this.rawText.substring(startPos, endPos);
-						int ordinal = ordinalIndexOf(raw, "]", dims); 
+						int ordinal = ordinalIndexOf(raw, "]", dims);
 						if( ordinal != -1 ) {
 							int indOf = ordinal + 1;
 							commonSettings(res, jcArrayType, indOf);
@@ -3048,7 +3044,7 @@ class JavacConverter {
 		jdt.setSourceRange(pos, endPos - pos);
 		return jdt;
 	}
-	
+
 	class FixPositions extends ASTVisitor {
 		private final String contents;
 

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -37,6 +37,7 @@ import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.DiagnosticSource;
 import com.sun.tools.javac.util.JCDiagnostic;
@@ -98,8 +99,11 @@ public class JavacProblemConverter {
 			case JCClassDecl jcClassDecl -> {
 				return getDiagnosticPosition(jcDiagnostic, jcClassDecl);
 			}
-			case JCVariableDecl JCVariableDecl -> {
-				return getDiagnosticPosition(jcDiagnostic, JCVariableDecl);
+			case JCVariableDecl jcVariableDecl -> {
+				return getDiagnosticPosition(jcDiagnostic, jcVariableDecl);
+			}
+			case JCMethodDecl jcMethodDecl -> {
+				return getDiagnosticPosition(jcDiagnostic, jcMethodDecl);
 			}
 			default -> {
 				org.eclipse.jface.text.Position result = getMissingReturnMethodDiagnostic(jcDiagnostic, context);
@@ -117,6 +121,19 @@ public class JavacProblemConverter {
 		return getDefaultPosition(diagnostic);
 	}
 
+	private static org.eclipse.jface.text.Position getDiagnosticPosition(JCDiagnostic jcDiagnostic,
+			JCMethodDecl jcMethodDecl) {
+		int startPosition = (int) jcDiagnostic.getPosition();
+		if (startPosition != Position.NOPOS) {
+			try {
+				String name = jcMethodDecl.getName().toString();
+				return getDiagnosticPosition(name, startPosition, jcDiagnostic);
+			} catch (IOException ex) {
+				ILog.get().error(ex.getMessage(), ex);
+			}
+		}
+		return getDefaultPosition(jcDiagnostic);
+	}
 	private static org.eclipse.jface.text.Position getDefaultPosition(Diagnostic<? extends JavaFileObject> diagnostic) {
 		int start = (int) Math.min(diagnostic.getPosition(), diagnostic.getStartPosition());
 		int end = (int) Math.max(diagnostic.getEndPosition() - 1, start);


### PR DESCRIPTION
(these quickfixes are for abstract methods with bodies).

- The range of the body needs to be correct in order for it to work
- Also fix the range of the diagnostic