### PR TITLE
Fix some "wrong type" quick fixes

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -670,6 +670,9 @@ public class JavacBindingResolver extends BindingResolver {
 			}
 		}
 		var jcTree = this.converter.domToJavac.get(expr);
+		if (jcTree instanceof JCMethodInvocation javacMethodInvocation) {
+			return this.bindings.getTypeBinding(javacMethodInvocation.meth.type.asMethodType().getReturnType());
+		}
 		if (jcTree instanceof JCFieldAccess jcFieldAccess) {
 			if (jcFieldAccess.type instanceof PackageType) {
 				return null;


### PR DESCRIPTION
- add arguments to the created problem
  - This is needed to get the quick fixes to show up in JDT UI
- Fix resolveBinding(Expression) for method invocations (it now properly returns the binding for the return type)
  - This fixes the "change variable type" quickfix