### PR TITLE
Fix the regression of rename type quickfix

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -133,7 +133,7 @@ public class JavacBindingResolver extends BindingResolver {
 		//
 		private Map<String, JavacTypeBinding> typeBinding = new HashMap<>();
 		public JavacTypeBinding getTypeBinding(com.sun.tools.javac.code.Type type) {
-			if (type instanceof ErrorType errorType && errorType.tsym == null && (errorType.getOriginalType() != com.sun.tools.javac.code.Type.noType)) {
+			if (type instanceof ErrorType errorType && (errorType.getOriginalType() != com.sun.tools.javac.code.Type.noType)) {
 				return getTypeBinding(errorType.getOriginalType());
 			}
 			JavacTypeBinding newInstance = new JavacTypeBinding(type, type.tsym, JavacBindingResolver.this) { };

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -103,7 +103,7 @@ public class JavacProblemConverter {
 				case JCVariableDecl jcVariableDecl: return getDiagnosticPosition(jcDiagnostic, jcVariableDecl);
 				case JCMethodDecl jcMethodDecl: return getDiagnosticPosition(jcDiagnostic, jcMethodDecl);
 				case JCFieldAccess jcFieldAccess:
-					if (getDiagnosticArgumentByType(jcDiagnostic, KindName.class) != KindName.PACKAGE) {
+					if (getDiagnosticArgumentByType(jcDiagnostic, KindName.class) != KindName.PACKAGE && getDiagnosticArgumentByType(jcDiagnostic, Symbol.PackageSymbol.class) == null) {
 						// TODO here, instead of recomputing a position, get the JDT DOM node and call the Name (which has a position)
 						return new org.eclipse.jface.text.Position(jcFieldAccess.getPreferredPosition() + 1, jcFieldAccess.getIdentifier().length());
 					}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -267,7 +267,8 @@ public class JavacProblemConverter {
 	private static org.eclipse.jface.text.Position getDiagnosticPosition(JCDiagnostic jcDiagnostic, JCClassDecl jcClassDecl) {
 		int startPosition = (int) jcDiagnostic.getPosition();
 		if (startPosition != Position.NOPOS &&
-			!jcClassDecl.getMembers().isEmpty() && jcClassDecl.getStartPosition() != jcClassDecl.getMembers().get(0).getStartPosition()) {
+			(jcClassDecl.getMembers().isEmpty() ||
+			(!jcClassDecl.getMembers().isEmpty() && jcClassDecl.getStartPosition() != jcClassDecl.getMembers().get(0).getStartPosition()))) {
 			try {
 				String name = jcClassDecl.getSimpleName().toString();
 				return getDiagnosticPosition(name, startPosition, jcDiagnostic);


### PR DESCRIPTION
eg. in a file called `X.java`:

```java
public enum E {

}
```

This PR fixes the error range and the two quick fixes to either rename the file or rename the type.

The root cause is that we need to handle classes with no body declaration in range adjustment.

**ALSO**

Fix "change visibility" for types with parameters

eg.

```java
package aaa;

class PackagePrivate<A> {}
```

```java
package aaa.bbb;

import aaa.PackagePrivate; // <-- HERE

class FooBar {
  void myMethod() {
    PackagePrivate<A> asdf = null;
  }
}
```

- Use recovered type "original" symbol in more cases
  (this might cause more regressions but so far seems good)
- Handle range for import cases better