### PR TITLE
Fix regression caused by #558

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -671,7 +671,10 @@ public class JavacBindingResolver extends BindingResolver {
 		}
 		var jcTree = this.converter.domToJavac.get(expr);
 		if (jcTree instanceof JCMethodInvocation javacMethodInvocation) {
-			return this.bindings.getTypeBinding(javacMethodInvocation.meth.type.asMethodType().getReturnType());
+			if (javacMethodInvocation.meth.type instanceof MethodType methodType) {
+				return this.bindings.getTypeBinding(methodType.getReturnType());
+			}
+			jcTree = javacMethodInvocation.meth;
 		}
 		if (jcTree instanceof JCFieldAccess jcFieldAccess) {
 			if (jcFieldAccess.type instanceof PackageType) {


### PR DESCRIPTION
Both the "create new method" and the "add cast to method invocation" cases should work now.