### PR TITLE
Handle erroneous method types in expression binding

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -673,8 +673,12 @@ public class JavacBindingResolver extends BindingResolver {
 		if (jcTree instanceof JCMethodInvocation javacMethodInvocation) {
 			if (javacMethodInvocation.meth.type instanceof MethodType methodType) {
 				return this.bindings.getTypeBinding(methodType.getReturnType());
+			} else if (javacMethodInvocation.meth.type instanceof ErrorType errorType)  {
+				if (errorType.getOriginalType() instanceof MethodType methodType) {
+					return this.bindings.getTypeBinding(methodType.getReturnType());
+				}
 			}
-			jcTree = javacMethodInvocation.meth;
+			return null;
 		}
 		if (jcTree instanceof JCFieldAccess jcFieldAccess) {
 			if (jcFieldAccess.type instanceof PackageType) {


### PR DESCRIPTION
When resolving the binding for the return type of method invocation, make sure to handle erroneous types properly.

This should fix issues related to "unknown method" quick fixes.