### PR TITLE
add support for static field imports binding resolution.

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -871,10 +871,16 @@ public class JavacBindingResolver extends BindingResolver {
 			if (importDeclaration.isStatic()) {
 				com.sun.tools.javac.code.Type type = fieldAccess.getExpression().type;
 				if (type != null) {
-					return Arrays.stream(this.bindings.getTypeBinding(type).getDeclaredMethods())
+					IBinding binding = Arrays.stream(this.bindings.getTypeBinding(type).getDeclaredMethods())
 						.filter(method -> Objects.equals(fieldAccess.getIdentifier().toString(), method.getName()))
 						.findAny()
 						.orElse(null);
+					if (binding == null) {
+						binding = Arrays.stream(this.bindings.getTypeBinding(type).getDeclaredFields()).filter(
+								field -> Objects.equals(fieldAccess.getIdentifier().toString(), field.getName()))
+								.findAny().orElse(null);
+					}
+					return binding;
 				}
 			}
 		}


### PR DESCRIPTION
Add support for resolving bindings on static field imports.

```
import static java.lang.Math.PI
```

Try to hover over the static import which will throw a NPE error and not symbol information will be provided in editor.