### PR TITLE
[WIP] do not use recovered bindings when performing code select

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -140,7 +140,9 @@ public class JavacBindingResolver extends BindingResolver {
 		private Map<String, JavacTypeBinding> typeBinding = new HashMap<>();
 		public JavacTypeBinding getTypeBinding(com.sun.tools.javac.code.Type type) {
 			if (type instanceof ErrorType errorType && (errorType.getOriginalType() != com.sun.tools.javac.code.Type.noType)) {
-				return getTypeBinding(errorType.getOriginalType());
+				JavacTypeBinding binding = getTypeBinding(errorType.getOriginalType());
+				binding.setRecovered(true);
+				return binding;
 			}
 			JavacTypeBinding newInstance = new JavacTypeBinding(type, type.tsym, JavacBindingResolver.this) { };
 			typeBinding.putIfAbsent(newInstance.getKey(), newInstance);

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -70,6 +70,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 	public final TypeSymbol typeSymbol;
 	private final Types types;
 	private final Type type;
+	private boolean recovered = false;
 
 	public JavacTypeBinding(final Type type, final TypeSymbol typeSymbol, JavacBindingResolver resolver) {
 		if (type instanceof PackageType) {
@@ -112,6 +113,9 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 
 	@Override
 	public boolean isRecovered() {
+		if (recovered) {
+			return true;
+		}
 		if (isArray()) {
 			return getComponentType().isRecovered();
 		}
@@ -765,6 +769,10 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 			return this.resolver.bindings.getModuleBinding(ps.modle);
 		}
 		return null;
+	}
+
+	public void setRecovered(boolean recovered) {
+		this.recovered = recovered;
 	}
 
 	@Override

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCodeSelector.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCodeSelector.java
@@ -243,7 +243,7 @@ public class DOMCodeSelector {
 			return new IJavaElement[] { importBinding.getJavaElement() };
 		} else if (findTypeDeclaration(node) == null) {
 			IBinding binding = resolveBinding(node);
-			if (binding != null) {
+			if (binding != null && !binding.isRecovered()) {
 				if (node instanceof SuperMethodInvocation && // on `super`
 					binding instanceof IMethodBinding methodBinding &&
 					methodBinding.getDeclaringClass() instanceof ITypeBinding typeBinding &&


### PR DESCRIPTION
- I think this is overkill, the recovered binding is often correct. However, I think this will fix the issue with duplicate type names being imported using `*`;

Fixes #577