### PR TITLE
include enum literal annotations

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -3153,6 +3153,8 @@ class JavacConverter {
 					typeName.internalSetIdentifier(enumName);
 					typeName.setSourceRange(enumConstant.getStartPosition(), Math.max(0, enumName.length()));
 					enumConstantDeclaration.setName(typeName);
+					enumConstantDeclaration.modifiers()
+							.addAll(convert(enumConstant.getModifiers(), enumConstantDeclaration));
 				}
 				if( enumConstant.init instanceof JCNewClass jcnc ) {
 					if( jcnc.def instanceof JCClassDecl jccd) {


### PR DESCRIPTION
Given following code snippet

```
package app;

import com.google.gson.annotations.SerializedName;

public enum Form {
    @SerializedName("tablet") TABLET, @SerializedName("infusion") INFUSION;
}
```

The annotation `@SerializedName` is not identified in the DOM tree.