### PR TITLE
include annotation modifiers for record components

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -592,6 +592,8 @@ class JavacConverter {
 					SingleVariableDeclaration vdd = (SingleVariableDeclaration)convertVariableDeclaration(vd);
 					// Records cannot have modifiers
 					vdd.modifiers().clear();
+					// Add only annotation modifiers
+					vdd.modifiers().addAll(convertModifierAnnotations(vd.getModifiers(), vdd));
 					recordDecl.recordComponents().add(vdd);
 				} else {
 					ASTNode converted = convertBodyDeclaration(node, res);


### PR DESCRIPTION
This fix include the record component annotations in the resulting DOM for the following code snippet. 

```
package app;

import com.google.gson.annotations.SerializedName;

public record Drug(@SerializedName("form") Form form) {
    
}
```
