### PR TITLE
Do not use errorneous recovered types

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -143,7 +143,8 @@ public class JavacBindingResolver extends BindingResolver {
 			if (type instanceof ErrorType errorType
 						&& (errorType.getOriginalType() != com.sun.tools.javac.code.Type.noType)
 						&& !(errorType.getOriginalType() instanceof com.sun.tools.javac.code.Type.MethodType)
-						& !(errorType.getOriginalType() instanceof com.sun.tools.javac.code.Type.ForAll)) {
+						&& !(errorType.getOriginalType() instanceof com.sun.tools.javac.code.Type.ForAll)
+						&& !(errorType.getOriginalType() instanceof com.sun.tools.javac.code.Type.ErrorType)) {
 				JavacTypeBinding binding = getTypeBinding(errorType.getOriginalType());
 				binding.setRecovered(true);
 				return binding;


### PR DESCRIPTION
Do not use the original (recovered) type if it's also erroneous, instead use the type stub.

Should fix a few tests, probably 4ish.