### PR TITLE
Fix error id for "annot param must be constant"

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -660,6 +660,7 @@ public class JavacProblemConverter {
 				}
 			}
 			case "compiler.err.non.sealed.sealed.or.final.expected" -> IProblem.SealedMissingClassModifier;
+			case "compiler.err.enum.annotation.must.be.enum.constant" -> IProblem.AnnotationValueMustBeAnEnumConstant;
 			default -> {
 				ILog.get().error("Could not convert diagnostic (" + diagnostic.getCode() + ")\n" + diagnostic);
 				yield 0;


### PR DESCRIPTION
- ~~Also fix a mostly unrelated classcast exception~~ Rob handled this already
  -  I have avoided the classcast exception but we still don't properly handle getting the name of eg. `MethodClass` in below or anonymous classes

```java
public class MyClass {
  public void foo() {
    class MethodClass {
      void bar() {
        System.out.println("Hello, World");
      }
    }
    new MethodClass().bar();
  }
}
```