### PR TITLE
Fix module compilation diagnostics

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
@@ -384,28 +384,32 @@ public class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 	}
 
 	private void resolveBindings(CompilationUnit unit, Map<String, IBinding> bindingMap, int apiLevel) {
-		if (unit.getPackage() != null) {
-			IPackageBinding pb = unit.getPackage().resolveBinding();
-			if (pb != null) {
-				bindingMap.put(pb.getKey(), pb);
-			}
-		}
-		if (!unit.types().isEmpty()) {
-			List<AbstractTypeDeclaration> types = unit.types();
-			for( int i = 0; i < types.size(); i++ ) {
-				ITypeBinding tb = ((AbstractTypeDeclaration) types.get(i)).resolveBinding();
-				if (tb != null) {
-					bindingMap.put(tb.getKey(), tb);
+		try {
+			if (unit.getPackage() != null) {
+				IPackageBinding pb = unit.getPackage().resolveBinding();
+				if (pb != null) {
+					bindingMap.put(pb.getKey(), pb);
 				}
 			}
-		}
-		if( apiLevel >= AST.JLS9_INTERNAL) {
-			if (unit.getModule() != null) {
-				IModuleBinding mb = unit.getModule().resolveBinding();
-				if (mb != null) {
-					bindingMap.put(mb.getKey(), mb);
+			if (!unit.types().isEmpty()) {
+				List<AbstractTypeDeclaration> types = unit.types();
+				for( int i = 0; i < types.size(); i++ ) {
+					ITypeBinding tb = ((AbstractTypeDeclaration) types.get(i)).resolveBinding();
+					if (tb != null) {
+						bindingMap.put(tb.getKey(), tb);
+					}
 				}
 			}
+			if( apiLevel >= AST.JLS9_INTERNAL) {
+				if (unit.getModule() != null) {
+					IModuleBinding mb = unit.getModule().resolveBinding();
+					if (mb != null) {
+						bindingMap.put(mb.getKey(), mb);
+					}
+				}
+			}
+		} catch (Exception e) {
+			ILog.get().warn("Failed to resolve binding", e);
 		}
 	}
 

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -675,6 +675,20 @@ public class JavacProblemConverter {
 			case "compiler.err.non.sealed.sealed.or.final.expected" -> IProblem.SealedMissingClassModifier;
 			case "compiler.err.enum.annotation.must.be.enum.constant" -> IProblem.AnnotationValueMustBeAnEnumConstant;
 			case "compiler.err.package.in.other.module" -> IProblem.ConflictingPackageFromOtherModules;
+			case "compiler.err.module.decl.sb.in.module-info.java" -> {
+				if (!(diagnostic instanceof JCDiagnostic jcDiagnostic)) {
+					yield 0;
+				}
+				DiagnosticPosition pos = jcDiagnostic.getDiagnosticPosition();
+				if (pos instanceof JCTree.JCModuleDecl) {
+					yield IProblem.ParsingErrorOnKeywordNoSuggestion;
+				} else if (pos instanceof JCTree.JCModuleImport) {
+				}
+				ILog.get().error("Could not convert diagnostic " + diagnostic);
+				yield 0;
+			}
+			case "compiler.err.file.sb.on.source.or.patch.path.for.module" -> IProblem.ParsingErrorOnKeywordNoSuggestion;
+			case "compiler.err.package.not.visible" -> IProblem.NotVisibleType;
 			default -> {
 				ILog.get().error("Could not convert diagnostic (" + diagnostic.getCode() + ")\n" + diagnostic);
 				yield 0;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -13789,15 +13789,20 @@ public final class CompletionEngine
 	 * <code>false</code> otherwise
 	 */
 	private boolean isFailedMatch(char[] token, char[] name) {
-		if ((this.options.substringMatch && CharOperation.substringMatch(token, name))
-				|| (this.options.camelCaseMatch && CharOperation.camelCaseMatch(token, name))
+		return isFailedMatch(token, name, this.options);
+	}
+
+	static boolean isFailedMatch(char[] token, char[] name, AssistOptions opt) {
+		if ((opt.substringMatch && CharOperation.substringMatch(token, name))
+				|| (opt.camelCaseMatch && CharOperation.camelCaseMatch(token, name))
 				|| CharOperation.prefixEquals(token, name, false)
-				|| (this.options.subwordMatch && CharOperation.subWordMatch(token, name))) {
+				|| (opt.subwordMatch && CharOperation.subWordMatch(token, name))) {
 			return false;
 		}
 
 		return true;
 	}
+
 	private boolean isForbidden(ReferenceBinding binding) {
 		for (int i = 0; i <= this.forbbidenBindingsPtr; i++) {
 			if(this.forbbidenBindings[i] == binding) {


### PR DESCRIPTION
- add diagnostic support
- suppress some issues that can be caused by syntax errors in module-info.java while trying to resolve binding which can cause a cascading failure in the diagnostic resolution. The suppressions are logged as warning since they are expected when syntax errors persist.
- add basic module-info completions