### PR TITLE
Fix for `JavacTypeBinding.getTypeArguments`

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -701,6 +701,8 @@ public class JavacProblemConverter {
 			case "compiler.err.expected4" -> IProblem.Syntax;
 			case "compiler.err.no.intf.expected.here" -> IProblem.SuperclassMustBeAClass;
 			case "compiler.err.intf.expected.here" -> IProblem.SuperInterfaceMustBeAnInterface;
+			case "compiler.err.method.does.not.override.superclass" -> IProblem.MethodMustOverrideOrImplement;
+			case "compiler.err.name.clash.same.erasure.no.override" -> IProblem.DuplicateMethodErasure;
 			default -> {
 				ILog.get().error("Could not convert diagnostic (" + diagnostic.getCode() + ")\n" + diagnostic);
 				yield 0;

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeVariableBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeVariableBinding.java
@@ -13,43 +13,68 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.javac.dom;
 
-import java.util.Objects;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.JavacBindingResolver;
 
 import com.sun.tools.javac.code.Symbol.TypeVariableSymbol;
+import com.sun.tools.javac.code.Type.TypeVar;
 
 /**
  * Note that this isn't API and isn't part of the IBinding tree type.
  * The sole purpose of this class is to help calculate getKey.
  */
-public abstract class JavacTypeVariableBinding {
-	private TypeVariableSymbol typeVar;
+public abstract class JavacTypeVariableBinding extends JavacTypeBinding {
+	private final TypeVariableSymbol sym;
+	private final JavacBindingResolver bindingResolver;
 
-	public JavacTypeVariableBinding(TypeVariableSymbol typeVar) {
-		this.typeVar = typeVar;
+	public JavacTypeVariableBinding(TypeVar type, TypeVariableSymbol sym, JavacBindingResolver bindingResolver) {
+		super(type, sym, bindingResolver);
+		this.sym = sym;
+		this.bindingResolver = bindingResolver;
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		return obj instanceof JavacTypeVariableBinding other
-				&& Objects.equals(this.typeVar, other.typeVar);
-	}
-	@Override
-	public int hashCode() {
-		return Objects.hash(this.typeVar);
-	}
-	
 	public String getKey() {
 		StringBuilder builder = new StringBuilder();
-		builder.append(typeVar.getSimpleName());
+		if (this.sym.owner != null) {
+			IBinding ownerBinding = this.bindingResolver.bindings.getBinding(this.sym.owner, null);
+			if (ownerBinding != null) {
+				builder.append(ownerBinding.getKey());
+			}
+		}
+		builder.append(":T");
+		builder.append(sym.getSimpleName());
+		builder.append(";");
+		return builder.toString();
+	}
+
+	@Override
+	public String getQualifiedName() {
+		return sym.getSimpleName().toString();
+	}
+
+	/**
+	 * this is the one that's used in method params and such, not the one that's actually used as it's final resting place (RIP)
+	 * @param sym
+	 * @return
+	 */
+	static String getTypeVariableKey(TypeVariableSymbol sym) {
+		StringBuilder builder = new StringBuilder();
+		builder.append(sym.getSimpleName());
 		builder.append(':');
-		boolean prependColon = typeVar.getBounds().size() > 1
-				|| (typeVar.getBounds().size() > 0 && typeVar.getBounds().get(0).isInterface());
-		for (var bound : typeVar.getBounds()) {
+		boolean prependColon = sym.getBounds().size() > 1
+				|| (sym.getBounds().size() > 0 && sym.getBounds().get(0).isInterface());
+		for (var bound : sym.getBounds()) {
 			if (prependColon) {
 				builder.append(":");
 			}
 			JavacTypeBinding.getKey(builder, bound, false);
 		}
 		return builder.toString();
+	}
+
+	@Override
+	public String toString() {
+		return getKey();
 	}
 }

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.internal.core.util.Util;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Kinds;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
@@ -149,7 +150,7 @@ public abstract class JavacVariableBinding implements IVariableBinding {
 			}
 			return builder.toString();
 		} else if (this.variableSymbol.owner instanceof MethodSymbol methodSymbol) {
-			JavacMethodBinding.getKey(builder, methodSymbol, this.resolver);
+			JavacMethodBinding.getKey(builder, methodSymbol, methodSymbol.type instanceof Type.MethodType methodType ? methodType : null, this.resolver);
 			builder.append('#');
 			builder.append(this.variableSymbol.name);
 			// FIXME: is it possible for the javac AST to contain multiple definitions of the same variable?
@@ -229,7 +230,10 @@ public abstract class JavacVariableBinding implements IVariableBinding {
 		Symbol parentSymbol = this.variableSymbol.owner;
 		do {
 			if (parentSymbol instanceof MethodSymbol method) {
-				return this.resolver.bindings.getMethodBinding(method.type.asMethodType(), method);
+				if (!(method.type instanceof Type.MethodType methodType)) {
+					return null;
+				}
+				return this.resolver.bindings.getMethodBinding(methodType, method);
 			}
 			parentSymbol = parentSymbol.owner;
 		} while (parentSymbol != null);


### PR DESCRIPTION
The main goal of this PR is to get the quick fix for the following case working:

```java
public class MyClass extends java.util.List {

}
```

I needed to redo a lot of the type variable and method param/arg code in order to accomplish this.