### PR TITLE
Fix 2 problem ids

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -704,6 +704,8 @@ public class JavacProblemConverter {
 			case "compiler.err.intf.expected.here" -> IProblem.SuperInterfaceMustBeAnInterface;
 			case "compiler.err.method.does.not.override.superclass" -> IProblem.MethodMustOverrideOrImplement;
 			case "compiler.err.name.clash.same.erasure.no.override" -> IProblem.DuplicateMethodErasure;
+			case "compiler.err.cant.deref" -> IProblem.NoMessageSendOnBaseType;
+			case "compiler.err.cant.infer.local.var.type" -> IProblem.VarLocalWithoutInitizalier;
 			default -> {
 				ILog.get().error("Could not convert diagnostic (" + diagnostic.getCode() + ")\n" + diagnostic);
 				yield 0;


### PR DESCRIPTION
- var in method without initializer (eg `var i;`)
- attempt to invoke `.toString()` on a method that returns `int`