### PR TITLE
Address the regressions (NPEs) caused by new `getTypeArgument()`

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -488,6 +488,7 @@ public class JavacProblemConverter {
 			case "compiler.err.illegal.start.of.type" -> IProblem.Syntax;
 			case "compiler.err.illegal.start.of.expr" -> IProblem.Syntax;
 			case "compiler.err.variable.not.allowed" -> IProblem.Syntax;
+			case "compiler.err.illegal.dot" -> IProblem.Syntax;
 			case "compiler.warn.raw.class.use" -> IProblem.RawTypeReference;
 			case "compiler.err.cant.resolve.location" -> switch (getDiagnosticArgumentByType(diagnostic, Kinds.KindName.class)) {
 					case CLASS -> IProblem.UndefinedType;
@@ -706,6 +707,7 @@ public class JavacProblemConverter {
 			case "compiler.err.name.clash.same.erasure.no.override" -> IProblem.DuplicateMethodErasure;
 			case "compiler.err.cant.deref" -> IProblem.NoMessageSendOnBaseType;
 			case "compiler.err.cant.infer.local.var.type" -> IProblem.VarLocalWithoutInitizalier;
+			case "compiler.err.array.and.varargs" -> IProblem.RedefinedArgument;
 			default -> {
 				ILog.get().error("Could not convert diagnostic (" + diagnostic.getCode() + ")\n" + diagnostic);
 				yield 0;

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorMethodBinding.java
@@ -12,6 +12,8 @@ package org.eclipse.jdt.internal.javac.dom;
 
 import java.util.Objects;
 
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.JavacBindingResolver;
 
@@ -75,4 +77,20 @@ public abstract class JavacErrorMethodBinding extends JavacMethodBinding {
 		}
 		return null;
 	}
+
+	@Override
+	public boolean isDeprecated() {
+		return this.originatingSymbol.isDeprecated();
+	}
+
+	@Override
+	public IMethodBinding getMethodDeclaration() {
+		return this.resolver.bindings.getErrorMethodBinding(this.resolver.getTypes().erasure(methodType).asMethodType(), originatingSymbol.type.tsym);
+	}
+
+	@Override
+	public IAnnotationBinding[] getAnnotations() {
+		return this.originatingSymbol.getAnnotationMirrors().stream().map(ann -> this.resolver.bindings.getAnnotationBinding(ann, this)).toArray(IAnnotationBinding[]::new);
+	}
+
 }


### PR DESCRIPTION
- Some additional problem id mappings encountered along the way