### PR TITLE
Fix an error that appears during malformed code

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -1010,7 +1010,7 @@ class JavacConverter {
 		int fragmentLength = fragmentEnd - fragmentStart; // ????  - 1;
 		fragment.setSourceRange(fragmentStart, Math.max(0, fragmentLength));
 		removeTrailingCharFromRange(fragment, new char[] {';', ','});
-		
+
 		if (convertName(javac.getName()) instanceof SimpleName simpleName) {
 			fragment.setName(simpleName);
 		}
@@ -2120,7 +2120,7 @@ class JavacConverter {
 			}
 			VariableDeclarationStatement res = this.ast.newVariableDeclarationStatement(fragment);
 			commonSettings(res, javac);
-			
+
 			if (jcVariableDecl.vartype != null) {
 				if( jcVariableDecl.vartype instanceof JCArrayTypeTree jcatt) {
 					int extraDims = 0;
@@ -2520,7 +2520,7 @@ class JavacConverter {
 			res.setSourceRange(res.getStartPosition(), res.getLength() + 1);
 		}
 	}
-	
+
 	private void removeTrailingCharFromRange(ASTNode res, char[] possible) {
 		int endPos = res.getStartPosition() + res.getLength();
 		char lastChar = this.rawText.charAt(endPos-1);
@@ -2534,7 +2534,7 @@ class JavacConverter {
 			res.setSourceRange(res.getStartPosition(), res.getLength() - 1);
 		}
 	}
-	
+
 	private CatchClause convertCatcher(JCCatch javac) {
 		CatchClause res = this.ast.newCatchClause();
 		commonSettings(res, javac);
@@ -2596,7 +2596,13 @@ class JavacConverter {
 			Type qualifierType = convertToType(qualified.getExpression());
 			SimpleName simpleName = (SimpleName)convertName(qualified.getIdentifier());
 			int simpleNameStart = this.rawText.indexOf(simpleName.getIdentifier(), qualifierType.getStartPosition() + qualifierType.getLength());
-			simpleName.setSourceRange(simpleNameStart, simpleName.getIdentifier().length());
+			if (simpleNameStart > 0) {
+				simpleName.setSourceRange(simpleNameStart, simpleName.getIdentifier().length());
+			} else {
+				// the name second segment is invalid
+				simpleName.delete();
+				return qualifierType;
+			}
 			if(qualifierType instanceof SimpleType simpleType && (ast.apiLevel() < AST.JLS8 || simpleType.annotations().isEmpty())) {
 				simpleType.delete();
 				Name parentName = simpleType.getName();

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
@@ -90,7 +90,7 @@ public abstract class JavacVariableBinding implements IVariableBinding {
 
 	@Override
 	public boolean isRecovered() {
-		return this.variableSymbol.kind == Kinds.Kind.ERR;
+		return this.variableSymbol.kind == Kinds.Kind.ERR || this.variableSymbol.type instanceof Type.ErrorType;
 	}
 
 	@Override

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
@@ -54,6 +54,7 @@ import org.eclipse.jdt.core.dom.ModuleDeclaration;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.NodeFinder;
 import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.Type;
@@ -203,7 +204,7 @@ public class DOMCompletionEngine implements Runnable {
 			int charCount = this.offset - simpleName.getStartPosition();
 			completeAfter = simpleName.getIdentifier().substring(0, charCount);
 			if (simpleName.getParent() instanceof FieldAccess || simpleName.getParent() instanceof MethodInvocation
-					|| simpleName.getParent() instanceof VariableDeclaration) {
+					|| simpleName.getParent() instanceof VariableDeclaration || simpleName.getParent() instanceof QualifiedName) {
 				context = this.toComplete.getParent();
 			}
 		}
@@ -304,9 +305,9 @@ public class DOMCompletionEngine implements Runnable {
 		if (context instanceof ModuleDeclaration mod) {
 			findModules(this.prefix.toCharArray(), this.modelUnit.getJavaProject(), this.assistOptions, Set.of(mod.getName().toString()));
 		}
-		
+
 		ASTNode current = this.toComplete;
-		
+
 		if(suggestDefaultCompletions) {
 			while (current != null) {
 				scope.addAll(visibleBindings(current));


### PR DESCRIPTION
If you type a `.` at the `|` with DOM-based completion enabled, then it used to generate an Exception related to DOM translation. Now, it won't generate that error.

```java
public class MyClass {
  void myMethod(int a, String b|) {

  }
}
```

I think this might fix a test case.