### PR TITLE
Adjust the diagnostic location for unused star import

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/UnusedProblemFactory.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/UnusedProblemFactory.java
@@ -69,6 +69,15 @@ public class UnusedProblemFactory {
 			JCImport importNode = unusedImport.getValue();
 			int pos = importNode.qualid.getStartPosition();
 			int endPos = pos + importName.length() - 1;
+			if (importName.endsWith(".*")) {
+				/**
+				 * For the unused star imports (e.g., java.util.*), display the
+				 * diagnostic on the java.util part instead of java.util.* to
+				 * be compatible with 'remove unused import' quickfix in JDT.
+				 */
+				importName = importName.substring(0, importName.length() - 2);
+				endPos = endPos - 2;
+			}
 			int line = (int) unit.getLineMap().getLineNumber(pos);
 			int column = (int) unit.getLineMap().getColumnNumber(pos);
 			String[] arguments = new String[] { importName };


### PR DESCRIPTION
This is used to make it compatible with the JDT quickfix.

Without this PR, the quick fix "remove unused import" won't appear on unused star import.

![image](https://github.com/user-attachments/assets/c515b1cf-ffe1-48aa-b34f-5a17f76c0bff)
