### PR TITLE
Fix organize imports tests by removing unnecessary type arguments from generic type name

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -635,7 +635,8 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 			res.append(typeSymbol.toString());
 		}
 		ITypeBinding[] typeArguments = getUncheckedTypeArguments(type, typeSymbol);
-		if (typeArguments.length > 0) {
+		boolean isTypeDeclaration = typeSymbol != null && typeSymbol.type == type;
+		if (!isTypeDeclaration && typeArguments.length > 0) {
 			res.append("<");
 			int i;
 			for (i = 0; i < typeArguments.length - 1; i++) {


### PR DESCRIPTION
Fixes #662 and other failed organize imports tests.

When resolving the getQualifiedName for the declaration type of a generic type, type arguments should not be included.