### PR TITLE
Fix ASTConverter_16Teest.testrecoredSemicolon

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -608,7 +608,7 @@ class JavacConverter {
 
 		} else if (res instanceof RecordDeclaration recordDecl) {
 			for (JCTree node : javacClassDecl.getMembers()) {
-				if (node instanceof JCVariableDecl vd) {
+				if (node instanceof JCVariableDecl vd && !vd.getModifiers().getFlags().contains(javax.lang.model.element.Modifier.STATIC)) {
 					SingleVariableDeclaration vdd = (SingleVariableDeclaration)convertVariableDeclaration(vd);
 					// Records cannot have modifiers
 					vdd.modifiers().clear();


### PR DESCRIPTION
Record static fields are part of the body declarations not of the record components.