### PR TITLE
Fix static import: Return a null binding for the errorneous recovered types

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -160,6 +160,10 @@ public class JavacBindingResolver extends BindingResolver {
 				return null;
 			}
 			if (type instanceof ErrorType errorType
+					&& errorType.getOriginalType() instanceof ErrorType) {
+				return null;
+			}
+			if (type instanceof ErrorType errorType
 						&& (errorType.getOriginalType() != com.sun.tools.javac.code.Type.noType)
 						&& !(errorType.getOriginalType() instanceof com.sun.tools.javac.code.Type.MethodType)
 						&& !(errorType.getOriginalType() instanceof com.sun.tools.javac.code.Type.ForAll)

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -160,10 +160,6 @@ public class JavacBindingResolver extends BindingResolver {
 				return null;
 			}
 			if (type instanceof ErrorType errorType
-					&& errorType.getOriginalType() instanceof ErrorType) {
-				return null;
-			}
-			if (type instanceof ErrorType errorType
 						&& (errorType.getOriginalType() != com.sun.tools.javac.code.Type.noType)
 						&& !(errorType.getOriginalType() instanceof com.sun.tools.javac.code.Type.MethodType)
 						&& !(errorType.getOriginalType() instanceof com.sun.tools.javac.code.Type.ForAll)
@@ -712,6 +708,10 @@ public class JavacBindingResolver extends BindingResolver {
 		}
 		
 		if (tree instanceof JCIdent ident && ident.sym != null) {
+			if (ident.type instanceof ErrorType errorType
+					&& errorType.getOriginalType() instanceof ErrorType) {
+				return null;
+			}
 			return this.bindings.getBinding(ident.sym, ident.type != null ? ident.type : ident.sym.type);
 		}
 		if (tree instanceof JCFieldAccess fieldAccess && fieldAccess.sym != null) {


### PR DESCRIPTION
This fixes two tests:
[org.eclipse.jdt.ls.core.internal.handlers.AdvancedOrganizeImportsHandlerTest.testStaticImports](https://ci.eclipse.org/ls/job/jdt-ls-javac/322/testReport/junit/org.eclipse.jdt.ls.core.internal.handlers/AdvancedOrganizeImportsHandlerTest/testStaticImports/)
[org.eclipse.jdt.ls.core.internal.handlers.AdvancedOrganizeImportsHandlerTest.testAmbiguousStaticImports](https://ci.eclipse.org/ls/job/jdt-ls-javac/322/testReport/junit/org.eclipse.jdt.ls.core.internal.handlers/AdvancedOrganizeImportsHandlerTest/testAmbiguousStaticImports/)

For the unresolved symbol references, it expects a null binding. otherwise, the operation 'organize imports' won't generate static imports.