### PR TITLE
Handle bounds in `getName()` (unqualified version)

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -113,12 +113,12 @@ public class JavacBindingResolver extends BindingResolver {
 		//
 		private Map<String, JavacMethodBinding> methodBindings = new HashMap<>();
 		public JavacMethodBinding getMethodBinding(MethodType methodType, MethodSymbol methodSymbol, com.sun.tools.javac.code.Type parentType) {
-			JavacMethodBinding newInstance = new JavacMethodBinding(methodType, methodSymbol, parentType, JavacBindingResolver.this) { };
+			JavacMethodBinding newInstance = new JavacMethodBinding(methodType, methodSymbol, parentType instanceof com.sun.tools.javac.code.Type.ClassType parentClassType ? parentClassType : null, JavacBindingResolver.this) { };
 			methodBindings.putIfAbsent(newInstance.getKey(), newInstance);
 			return methodBindings.get(newInstance.getKey());
 		}
 		public JavacMethodBinding getErrorMethodBinding(MethodType methodType, Symbol originatingSymbol) {
-			JavacMethodBinding newInstance = new JavacErrorMethodBinding(originatingSymbol, methodType, originatingSymbol.owner.type, JavacBindingResolver.this) { };
+			JavacMethodBinding newInstance = new JavacErrorMethodBinding(originatingSymbol, methodType, originatingSymbol.owner.type instanceof com.sun.tools.javac.code.Type.ClassType parentClassType ? parentClassType : null, JavacBindingResolver.this) { };
 			methodBindings.putIfAbsent(newInstance.getKey(), newInstance);
 			return methodBindings.get(newInstance.getKey());
 		}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -112,13 +112,13 @@ public class JavacBindingResolver extends BindingResolver {
 		}
 		//
 		private Map<String, JavacMethodBinding> methodBindings = new HashMap<>();
-		public JavacMethodBinding getMethodBinding(MethodType methodType, MethodSymbol methodSymbol) {
-			JavacMethodBinding newInstance = new JavacMethodBinding(methodType, methodSymbol, JavacBindingResolver.this) { };
+		public JavacMethodBinding getMethodBinding(MethodType methodType, MethodSymbol methodSymbol, com.sun.tools.javac.code.Type parentType) {
+			JavacMethodBinding newInstance = new JavacMethodBinding(methodType, methodSymbol, parentType, JavacBindingResolver.this) { };
 			methodBindings.putIfAbsent(newInstance.getKey(), newInstance);
 			return methodBindings.get(newInstance.getKey());
 		}
 		public JavacMethodBinding getErrorMethodBinding(MethodType methodType, Symbol originatingSymbol) {
-			JavacMethodBinding newInstance = new JavacErrorMethodBinding(originatingSymbol, methodType, JavacBindingResolver.this) { };
+			JavacMethodBinding newInstance = new JavacErrorMethodBinding(originatingSymbol, methodType, originatingSymbol.owner.type, JavacBindingResolver.this) { };
 			methodBindings.putIfAbsent(newInstance.getKey(), newInstance);
 			return methodBindings.get(newInstance.getKey());
 		}
@@ -218,7 +218,7 @@ public class JavacBindingResolver extends BindingResolver {
 			} else if (owner instanceof TypeSymbol typeSymbol) {
 				return getTypeBinding(typeSymbol.type);
 			} else if (owner instanceof final MethodSymbol other) {
-				return getMethodBinding(type instanceof com.sun.tools.javac.code.Type.MethodType methodType ? methodType : owner.type.asMethodType(), other);
+				return getMethodBinding(type instanceof com.sun.tools.javac.code.Type.MethodType methodType ? methodType : owner.type.asMethodType(), other, other.owner.type);
 			} else if (owner instanceof final VarSymbol other) {
 				return getVariableBinding(other);
 			}
@@ -508,13 +508,13 @@ public class JavacBindingResolver extends BindingResolver {
 			javacElement instanceof JCFieldAccess fieldAccess ? fieldAccess.sym :
 				null;
 		if (type instanceof MethodType methodType && sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(methodType, methodSymbol);
+			return this.bindings.getMethodBinding(methodType, methodSymbol, type);
 		}
 		if (type instanceof ErrorType errorType && errorType.getOriginalType() instanceof MethodType methodType) {
 			if (sym.owner instanceof TypeSymbol typeSymbol) {
 				Iterator<Symbol> methods = typeSymbol.members().getSymbolsByName(sym.getSimpleName(), m -> m instanceof MethodSymbol && methodType.equals(m.type)).iterator();
 				if (methods.hasNext()) {
-					return this.bindings.getMethodBinding(methodType, (MethodSymbol)methods.next());
+					return this.bindings.getMethodBinding(methodType, (MethodSymbol)methods.next(), type);
 				}
 			}
 			return this.bindings.getErrorMethodBinding(methodType, sym);
@@ -527,7 +527,7 @@ public class JavacBindingResolver extends BindingResolver {
 		resolve();
 		JCTree javacElement = this.converter.domToJavac.get(method);
 		if (javacElement instanceof JCMethodDecl methodDecl && methodDecl.type != null) {
-			return this.bindings.getMethodBinding(methodDecl.type.asMethodType(), methodDecl.sym);
+			return this.bindings.getMethodBinding(methodDecl.type.asMethodType(), methodDecl.sym, methodDecl.sym.owner.type);
 		}
 		return null;
 	}
@@ -550,7 +550,7 @@ public class JavacBindingResolver extends BindingResolver {
 		resolve();
 		JCTree javacElement = this.converter.domToJavac.get(methodReference);
 		if (javacElement instanceof JCMemberReference memberRef && memberRef.sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(memberRef.referentType.asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(memberRef.referentType.asMethodType(), methodSymbol, memberRef.getQualifierExpression().type);
 		}
 		return null;
 	}
@@ -560,7 +560,7 @@ public class JavacBindingResolver extends BindingResolver {
 		resolve();
 		JCTree javacElement = this.converter.domToJavac.get(member);
 		if (javacElement instanceof JCMethodDecl methodDecl) {
-			return this.bindings.getMethodBinding(methodDecl.type.asMethodType(), methodDecl.sym);
+			return this.bindings.getMethodBinding(methodDecl.type.asMethodType(), methodDecl.sym, methodDecl.sym.owner.type);
 		}
 		return null;
 	}
@@ -574,7 +574,7 @@ public class JavacBindingResolver extends BindingResolver {
 		}
 		return javacElement instanceof JCNewClass jcExpr
 				&& !jcExpr.constructor.type.isErroneous()?
-						this.bindings.getMethodBinding(jcExpr.constructor.type.asMethodType(), (MethodSymbol)jcExpr.constructor) :
+						this.bindings.getMethodBinding(jcExpr.constructor.type.asMethodType(), (MethodSymbol)jcExpr.constructor, jcExpr.type) :
 				null;
 	}
 
@@ -586,10 +586,10 @@ public class JavacBindingResolver extends BindingResolver {
 			javacElement = javacMethodInvocation.getMethodSelect();
 		}
 		if (javacElement instanceof JCIdent ident && ident.sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(ident.type != null ? ident.type.asMethodType() : methodSymbol.asType().asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(ident.type != null ? ident.type.asMethodType() : methodSymbol.asType().asMethodType(), methodSymbol, methodSymbol.owner.type);
 		}
 		if (javacElement instanceof JCFieldAccess fieldAccess && fieldAccess.sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(fieldAccess.type.asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(fieldAccess.type.asMethodType(), methodSymbol, fieldAccess.selected.type);
 		}
 		return null;
 	}
@@ -602,11 +602,11 @@ public class JavacBindingResolver extends BindingResolver {
 			javacElement = javacMethodInvocation.getMethodSelect();
 		}
 		if (javacElement instanceof JCIdent ident && ident.sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(ident.type.asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(ident.type.asMethodType(), methodSymbol, methodSymbol.owner.type);
 		}
 		if (javacElement instanceof JCFieldAccess fieldAccess && fieldAccess.sym instanceof MethodSymbol methodSymbol
 				&& fieldAccess.type != null /* when there are syntax errors */) {
-			return this.bindings.getMethodBinding(fieldAccess.type.asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(fieldAccess.type.asMethodType(), methodSymbol, fieldAccess.selected.type);
 		}
 		return null;
 	}
@@ -683,7 +683,7 @@ public class JavacBindingResolver extends BindingResolver {
 				}
 			}
 		}
-		
+
 		if (tree instanceof JCIdent ident && ident.sym != null) {
 			return this.bindings.getBinding(ident.sym, ident.type != null ? ident.type : ident.sym.type);
 		}
@@ -831,7 +831,7 @@ public class JavacBindingResolver extends BindingResolver {
 		return this.converter.domToJavac.get(expression) instanceof JCNewClass jcExpr
 				&& jcExpr.constructor != null
 				&& !jcExpr.constructor.type.isErroneous()?
-						this.bindings.getMethodBinding(jcExpr.constructor.type.asMethodType(), (MethodSymbol)jcExpr.constructor) :
+						this.bindings.getMethodBinding(jcExpr.constructor.type.asMethodType(), (MethodSymbol)jcExpr.constructor, jcExpr.type) :
 				null;
 	}
 
@@ -847,10 +847,10 @@ public class JavacBindingResolver extends BindingResolver {
 			javacElement = javacMethodInvocation.getMethodSelect();
 		}
 		if (javacElement instanceof JCIdent ident && ident.sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(ident.type != null ? ident.type.asMethodType() : methodSymbol.type.asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(ident.type != null ? ident.type.asMethodType() : methodSymbol.type.asMethodType(), methodSymbol, methodSymbol.owner.type);
 		}
 		if (javacElement instanceof JCFieldAccess fieldAccess && fieldAccess.sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(fieldAccess.type.asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(fieldAccess.type.asMethodType(), methodSymbol, fieldAccess.selected.type);
 		}
 		return null;
 	}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorMethodBinding.java
@@ -28,7 +28,7 @@ public abstract class JavacErrorMethodBinding extends JavacMethodBinding {
 
 	private Symbol originatingSymbol;
 
-	public JavacErrorMethodBinding(Symbol originatingSymbol, MethodType methodType, Type parentType, JavacBindingResolver resolver) {
+	public JavacErrorMethodBinding(Symbol originatingSymbol, MethodType methodType, Type.ClassType parentType, JavacBindingResolver resolver) {
 		super(methodType, null, parentType, resolver);
 		this.originatingSymbol = originatingSymbol;
 	}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorMethodBinding.java
@@ -28,8 +28,8 @@ public abstract class JavacErrorMethodBinding extends JavacMethodBinding {
 
 	private Symbol originatingSymbol;
 
-	public JavacErrorMethodBinding(Symbol originatingSymbol, MethodType methodType, JavacBindingResolver resolver) {
-		super(methodType, null, resolver);
+	public JavacErrorMethodBinding(Symbol originatingSymbol, MethodType methodType, Type parentType, JavacBindingResolver resolver) {
+		super(methodType, null, parentType, resolver);
 		this.originatingSymbol = originatingSymbol;
 	}
 

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacLambdaBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacLambdaBinding.java
@@ -15,7 +15,7 @@ import org.eclipse.jdt.core.dom.Modifier;
 public class JavacLambdaBinding extends JavacMethodBinding {
 
 	public JavacLambdaBinding(JavacMethodBinding methodBinding) {
-		super(methodBinding.methodType, methodBinding.methodSymbol, methodBinding.resolver);
+		super(methodBinding.methodType, methodBinding.methodSymbol, methodBinding.parentType, methodBinding.resolver);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMemberValuePairBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMemberValuePairBinding.java
@@ -29,7 +29,7 @@ public abstract class JavacMemberValuePairBinding implements IMemberValuePairBin
 	private final JavacBindingResolver resolver;
 
 	public JavacMemberValuePairBinding(MethodSymbol key, Attribute value, JavacBindingResolver resolver) {
-		this.method = resolver.bindings.getMethodBinding(key.type.asMethodType(), key);
+		this.method = resolver.bindings.getMethodBinding(key.type.asMethodType(), key, value.type);
 		this.value = value;
 		this.resolver = resolver;
 	}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
@@ -362,16 +362,18 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 
 	@Override
 	public ITypeBinding getDeclaringClass() {
-		return this.resolver.bindings.getTypeBinding(parentType);
+		if (parentType != null ) {
+			return this.resolver.bindings.getTypeBinding(parentType);
+		}
 		// probably incorrect as it may not return the actual declaring type, see getJavaElement()
-//		Symbol parentSymbol = this.methodSymbol.owner;
-//		do {
-//			if (parentSymbol instanceof ClassSymbol clazz) {
-//				return this.resolver.bindings.getTypeBinding(clazz.type);
-//			}
-//			parentSymbol = parentSymbol.owner;
-//		} while (parentSymbol != null);
-//		return null;
+		Symbol parentSymbol = this.methodSymbol.owner;
+		do {
+			if (parentSymbol instanceof ClassSymbol clazz) {
+				return this.resolver.bindings.getTypeBinding(clazz.type);
+			}
+			parentSymbol = parentSymbol.owner;
+		} while (parentSymbol != null);
+		return null;
 	}
 
 	@Override
@@ -506,7 +508,7 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 		// This method intentionally converts the type to its generic type,
 		// i.e. drops the type arguments
 		// i.e. <code>this.<String>getValue(12);</code> will be converted back to <code><T> T getValue(int i) {</code>
-		return this.resolver.bindings.getMethodBinding((MethodType)methodSymbol.type, methodSymbol, methodSymbol.owner.type);
+		return this.resolver.bindings.getMethodBinding(methodSymbol.type.asMethodType(), methodSymbol, methodSymbol.owner.type);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -158,7 +158,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 				return ownerType.getTypeParameter(this.getName());
 			} else if (this.typeSymbol.owner instanceof MethodSymbol ownerSymbol
 					&& ownerSymbol.type != null
-					&& this.resolver.bindings.getMethodBinding(ownerSymbol.type.asMethodType(), ownerSymbol).getJavaElement() instanceof IMethod ownerMethod
+					&& this.resolver.bindings.getMethodBinding(ownerSymbol.type.asMethodType(), ownerSymbol, this.type).getJavaElement() instanceof IMethod ownerMethod
 					&& ownerMethod.getTypeParameter(this.getName()) != null) {
 				return ownerMethod.getTypeParameter(this.getName());
 			}
@@ -427,7 +427,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 			.map(MethodSymbol.class::cast)
 			.map(sym -> {
 				Type.MethodType methodType = this.types.memberType(this.type, sym).asMethodType();
-				return this.resolver.bindings.getMethodBinding(methodType, sym);
+				return this.resolver.bindings.getMethodBinding(methodType, sym, this.type);
 			})
 			.toArray(IMethodBinding[]::new);
 	}
@@ -470,10 +470,10 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 		do {
 			if (parentSymbol instanceof final MethodSymbol method) {
 				if (method.type instanceof Type.MethodType methodType) {
-					return this.resolver.bindings.getMethodBinding(methodType, method);
+					return this.resolver.bindings.getMethodBinding(methodType, method, method.owner.type);
 				}
 				if( method.type instanceof Type.ForAll faType && faType.qtype instanceof MethodType mtt) {
-					IMethodBinding found = this.resolver.bindings.getMethodBinding(mtt, method);
+					IMethodBinding found = this.resolver.bindings.getMethodBinding(mtt, method, method.owner.type);
 					return found;
 				}
 				return null;
@@ -518,7 +518,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 		try {
 			Symbol symbol = types.findDescriptorSymbol(this.typeSymbol);
 			if (symbol instanceof MethodSymbol methodSymbol) {
-				return this.resolver.bindings.getMethodBinding(methodSymbol.type.asMethodType(), methodSymbol);
+				return this.resolver.bindings.getMethodBinding(methodSymbol.type.asMethodType(), methodSymbol, this.type);
 			}
 		} catch (FunctionDescriptorLookupError ignore) {
 		}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -178,7 +178,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 					return type.getType("", 1);
 				}
 			}
-			
+
 			JavaFileObject jfo = classSymbol == null ? null : classSymbol.sourcefile;
 			ICompilationUnit tmp = jfo == null ? null : getCompilationUnit(jfo.getName().toCharArray(), this.resolver.getWorkingCopyOwner());
 			if( tmp != null ) {
@@ -193,9 +193,9 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 					if( ret == null )
 						done = true;
 				}
-				if( ret != null ) 
+				if( ret != null )
 					return ret;
-			} 
+			}
 			try {
 				IType ret = this.resolver.javaProject.findType(cleanedUpName(this.type), this.resolver.getWorkingCopyOwner(), new NullProgressMonitor());
 				return ret;
@@ -565,6 +565,19 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 			}
 			return builder.toString();
 		}
+		if (type instanceof WildcardType wt) {
+			if (wt.type == null || this.resolver.resolveWellKnownType("java.lang.Object").equals(this.resolver.bindings.getTypeBinding(wt.type))) {
+				return "?";
+			}
+			StringBuilder builder = new StringBuilder("? ");
+			if (wt.isExtendsBound()) {
+				builder.append("extends ");
+			} else if (wt.isSuperBound()) {
+				builder.append("super ");
+			}
+			builder.append(this.resolver.bindings.getTypeBinding(wt.type).getName());
+			return builder.toString();
+		}
 		StringBuilder builder = new StringBuilder(this.typeSymbol.getSimpleName().toString());
 		if (this.getTypeArguments().length > 0) {
 			builder.append("<");
@@ -713,7 +726,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 	public ITypeBinding[] getTypeArguments() {
 		return getTypeArguments(this.type, this.typeSymbol);
 	}
-	
+
 	private ITypeBinding[] getTypeArguments(Type t, TypeSymbol ts) {
 		if (t.getTypeArguments().isEmpty() || t == ts.type || isTargettingPreGenerics()) {
 			return NO_TYPE_ARGUMENTS;

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
@@ -150,7 +150,7 @@ public abstract class JavacVariableBinding implements IVariableBinding {
 			}
 			return builder.toString();
 		} else if (this.variableSymbol.owner instanceof MethodSymbol methodSymbol) {
-			JavacMethodBinding.getKey(builder, methodSymbol, methodSymbol.type instanceof Type.MethodType methodType ? methodType : null, this.resolver);
+			JavacMethodBinding.getKey(builder, methodSymbol, methodSymbol.type instanceof Type.MethodType methodType ? methodType : null, methodSymbol.owner.type, this.resolver);
 			builder.append('#');
 			builder.append(this.variableSymbol.name);
 			// FIXME: is it possible for the javac AST to contain multiple definitions of the same variable?

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
@@ -233,7 +233,7 @@ public abstract class JavacVariableBinding implements IVariableBinding {
 				if (!(method.type instanceof Type.MethodType methodType)) {
 					return null;
 				}
-				return this.resolver.bindings.getMethodBinding(methodType, method);
+				return this.resolver.bindings.getMethodBinding(methodType, method, method.owner.type);
 			}
 			parentSymbol = parentSymbol.owner;
 		} while (parentSymbol != null);


### PR DESCRIPTION
This should push a couple jdt-ls tests to fail a bit later than they did before.