### PR TITLE
Fix the problem mapper for NotVisibleConstructorInDefaultConstructor

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -1072,6 +1072,14 @@ public class JavacProblemConverter {
 		if (diagnostic instanceof JCDiagnostic jcDiagnostic) {
 			Object[] args = jcDiagnostic.getArgs();
 			if (args != null && args.length > 0) {
+				if (args[0] instanceof Kinds.KindName kindName && kindName == Kinds.KindName.CONSTRUCTOR) {
+					Object lastArg = args[args.length - 1];
+					if (lastArg instanceof JCDiagnostic subDiagnostic) {
+						args = subDiagnostic.getArgs();
+					} else {
+						return IProblem.NotVisibleConstructor;
+					}
+				}
 				if (args[0] instanceof Symbol.MethodSymbol methodSymbol) {
 					if (methodSymbol.isConstructor()) {
 						if (jcDiagnostic.getDiagnosticPosition() instanceof JCTree.JCIdent id


### PR DESCRIPTION
This fixes the test [org.eclipse.jdt.ls.core.internal.correction.ConstructorQuickFixTest.testNotVisibleConstructorFromSuperClass](https://ci.eclipse.org/ls/job/jdt-ls-javac/339/testReport/junit/org.eclipse.jdt.ls.core.internal.correction/ConstructorQuickFixTest/testNotVisibleConstructorFromSuperClass/)

// F.java
```java
public class F {
	private F() {
		
	}

	public F(Runnable runnable) {
		
	}
}
```

// E.java
```java
public class E extends F {

}
```