### PR TITLE
Fix message for quickfixes for "wrong number of args" in generic constructor

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -106,7 +106,7 @@ public class JavacBindingResolver extends BindingResolver {
 	    	super(message, cause);
 	    }
 	}
-	
+
 	public class Bindings {
 		private Map<String, JavacAnnotationBinding> annotationBindings = new HashMap<>();
 		public JavacAnnotationBinding getAnnotationBinding(Compound ann, IBinding recipient) {
@@ -115,7 +115,7 @@ public class JavacBindingResolver extends BindingResolver {
 			if( k != null ) {
 				annotationBindings.putIfAbsent(k, newInstance);
 				return annotationBindings.get(k);
-			} 
+			}
 			return null;
 		}
 		//
@@ -131,8 +131,8 @@ public class JavacBindingResolver extends BindingResolver {
 		}
 		//
 		private Map<String, JavacMethodBinding> methodBindings = new HashMap<>();
-		public JavacMethodBinding getMethodBinding(MethodType methodType, MethodSymbol methodSymbol) {
-			JavacMethodBinding newInstance = new JavacMethodBinding(methodType, methodSymbol, JavacBindingResolver.this) { };
+		public JavacMethodBinding getMethodBinding(MethodType methodType, MethodSymbol methodSymbol, com.sun.tools.javac.code.Type parentType) {
+			JavacMethodBinding newInstance = new JavacMethodBinding(methodType, methodSymbol, parentType, JavacBindingResolver.this) { };
 			String k = newInstance.getKey();
 			if( k != null ) {
 				methodBindings.putIfAbsent(k, newInstance);
@@ -283,7 +283,7 @@ public class JavacBindingResolver extends BindingResolver {
 			} else if (owner instanceof TypeSymbol typeSymbol) {
 				return getTypeBinding(typeSymbol.type);
 			} else if (owner instanceof final MethodSymbol other) {
-				return getMethodBinding(type instanceof com.sun.tools.javac.code.Type.MethodType methodType ? methodType : owner.type.asMethodType(), other);
+				return getMethodBinding(type instanceof com.sun.tools.javac.code.Type.MethodType methodType ? methodType : owner.type.asMethodType(), other, null);
 			} else if (owner instanceof final VarSymbol other) {
 				return getVariableBinding(other);
 			}
@@ -584,7 +584,7 @@ public class JavacBindingResolver extends BindingResolver {
 			if (type != null &&
 				type.tsym.members().findFirst(ident.getName(), MethodSymbol.class::isInstance) instanceof MethodSymbol methodSymbol &&
 				methodSymbol.type instanceof MethodType methodType) {
-				var res = this.bindings.getMethodBinding(methodType, methodSymbol);
+				var res = this.bindings.getMethodBinding(methodType, methodSymbol, null);
 				if (res != null) {
 					return res;
 				}
@@ -594,13 +594,13 @@ public class JavacBindingResolver extends BindingResolver {
 			javacElement instanceof JCFieldAccess fieldAccess ? fieldAccess.sym :
 				null;
 		if (type instanceof MethodType methodType && sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(methodType, methodSymbol);
+			return this.bindings.getMethodBinding(methodType, methodSymbol, null);
 		}
 		if (type instanceof ErrorType errorType && errorType.getOriginalType() instanceof MethodType methodType) {
 			if (sym.owner instanceof TypeSymbol typeSymbol) {
 				Iterator<Symbol> methods = typeSymbol.members().getSymbolsByName(sym.getSimpleName(), m -> m instanceof MethodSymbol && methodType.equals(m.type)).iterator();
 				if (methods.hasNext()) {
-					return this.bindings.getMethodBinding(methodType, (MethodSymbol)methods.next());
+					return this.bindings.getMethodBinding(methodType, (MethodSymbol)methods.next(), null);
 				}
 			}
 			return this.bindings.getErrorMethodBinding(methodType, sym);
@@ -613,7 +613,7 @@ public class JavacBindingResolver extends BindingResolver {
 		resolve();
 		JCTree javacElement = this.converter.domToJavac.get(method);
 		if (javacElement instanceof JCMethodDecl methodDecl && methodDecl.type != null) {
-			return this.bindings.getMethodBinding(methodDecl.type.asMethodType(), methodDecl.sym);
+			return this.bindings.getMethodBinding(methodDecl.type.asMethodType(), methodDecl.sym, null);
 		}
 		return null;
 	}
@@ -636,7 +636,7 @@ public class JavacBindingResolver extends BindingResolver {
 		resolve();
 		JCTree javacElement = this.converter.domToJavac.get(methodReference);
 		if (javacElement instanceof JCMemberReference memberRef && memberRef.sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(memberRef.referentType.asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(memberRef.referentType.asMethodType(), methodSymbol, null);
 		}
 		return null;
 	}
@@ -646,7 +646,7 @@ public class JavacBindingResolver extends BindingResolver {
 		resolve();
 		JCTree javacElement = this.converter.domToJavac.get(member);
 		if (javacElement instanceof JCMethodDecl methodDecl) {
-			return this.bindings.getMethodBinding(methodDecl.type.asMethodType(), methodDecl.sym);
+			return this.bindings.getMethodBinding(methodDecl.type.asMethodType(), methodDecl.sym, null);
 		}
 		return null;
 	}
@@ -660,7 +660,7 @@ public class JavacBindingResolver extends BindingResolver {
 		}
 		return javacElement instanceof JCNewClass jcExpr
 				&& !jcExpr.constructor.type.isErroneous()?
-						this.bindings.getMethodBinding(jcExpr.constructor.type.asMethodType(), (MethodSymbol)jcExpr.constructor) :
+						this.bindings.getMethodBinding(jcExpr.constructor.type.asMethodType(), (MethodSymbol)jcExpr.constructor, null) :
 				null;
 	}
 
@@ -672,10 +672,10 @@ public class JavacBindingResolver extends BindingResolver {
 			javacElement = javacMethodInvocation.getMethodSelect();
 		}
 		if (javacElement instanceof JCIdent ident && ident.sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(ident.type != null ? ident.type.asMethodType() : methodSymbol.asType().asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(ident.type != null ? ident.type.asMethodType() : methodSymbol.asType().asMethodType(), methodSymbol, null);
 		}
 		if (javacElement instanceof JCFieldAccess fieldAccess && fieldAccess.sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(fieldAccess.type.asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(fieldAccess.type.asMethodType(), methodSymbol, null);
 		}
 		return null;
 	}
@@ -688,11 +688,11 @@ public class JavacBindingResolver extends BindingResolver {
 			javacElement = javacMethodInvocation.getMethodSelect();
 		}
 		if (javacElement instanceof JCIdent ident && ident.sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(ident.type.asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(ident.type.asMethodType(), methodSymbol, null);
 		}
 		if (javacElement instanceof JCFieldAccess fieldAccess && fieldAccess.sym instanceof MethodSymbol methodSymbol
 				&& fieldAccess.type != null /* when there are syntax errors */) {
-			return this.bindings.getMethodBinding(fieldAccess.type.asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(fieldAccess.type.asMethodType(), methodSymbol, null);
 		}
 		return null;
 	}
@@ -769,7 +769,7 @@ public class JavacBindingResolver extends BindingResolver {
 				}
 			}
 		}
-		
+
 		if (tree instanceof JCIdent ident && ident.sym != null) {
 			if (ident.type instanceof ErrorType errorType
 					&& errorType.getOriginalType() instanceof ErrorType) {
@@ -921,7 +921,7 @@ public class JavacBindingResolver extends BindingResolver {
 		return this.converter.domToJavac.get(expression) instanceof JCNewClass jcExpr
 				&& jcExpr.constructor != null
 				&& !jcExpr.constructor.type.isErroneous()?
-						this.bindings.getMethodBinding(jcExpr.constructor.type.asMethodType(), (MethodSymbol)jcExpr.constructor) :
+						this.bindings.getMethodBinding(jcExpr.constructor.type.asMethodType(), (MethodSymbol)jcExpr.constructor, null) :
 				null;
 	}
 
@@ -937,10 +937,10 @@ public class JavacBindingResolver extends BindingResolver {
 			javacElement = javacMethodInvocation.getMethodSelect();
 		}
 		if (javacElement instanceof JCIdent ident && ident.sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(ident.type != null ? ident.type.asMethodType() : methodSymbol.type.asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(ident.type != null ? ident.type.asMethodType() : methodSymbol.type.asMethodType(), methodSymbol, null);
 		}
 		if (javacElement instanceof JCFieldAccess fieldAccess && fieldAccess.sym instanceof MethodSymbol methodSymbol) {
-			return this.bindings.getMethodBinding(fieldAccess.type.asMethodType(), methodSymbol);
+			return this.bindings.getMethodBinding(fieldAccess.type.asMethodType(), methodSymbol, null);
 		}
 		return null;
 	}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorMethodBinding.java
@@ -30,7 +30,7 @@ public abstract class JavacErrorMethodBinding extends JavacMethodBinding {
 	private Symbol originatingSymbol;
 
 	public JavacErrorMethodBinding(Symbol originatingSymbol, MethodType methodType, JavacBindingResolver resolver) {
-		super(methodType, null, resolver);
+		super(methodType, null, null, resolver);
 		this.originatingSymbol = originatingSymbol;
 	}
 

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacLambdaBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacLambdaBinding.java
@@ -15,7 +15,7 @@ import org.eclipse.jdt.core.dom.Modifier;
 public class JavacLambdaBinding extends JavacMethodBinding {
 
 	public JavacLambdaBinding(JavacMethodBinding methodBinding) {
-		super(methodBinding.methodType, methodBinding.methodSymbol, methodBinding.resolver);
+		super(methodBinding.methodType, methodBinding.methodSymbol, methodBinding.parentType, methodBinding.resolver);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMemberValuePairBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMemberValuePairBinding.java
@@ -29,7 +29,7 @@ public abstract class JavacMemberValuePairBinding implements IMemberValuePairBin
 	private final JavacBindingResolver resolver;
 
 	public JavacMemberValuePairBinding(MethodSymbol key, Attribute value, JavacBindingResolver resolver) {
-		this.method = resolver.bindings.getMethodBinding(key.type.asMethodType(), key);
+		this.method = resolver.bindings.getMethodBinding(key.type.asMethodType(), key, null);
 		this.value = value;
 		this.resolver = resolver;
 	}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
@@ -158,7 +158,7 @@ public abstract class JavacVariableBinding implements IVariableBinding {
 			}
 			return builder.toString();
 		} else if (this.variableSymbol.owner instanceof MethodSymbol methodSymbol) {
-			JavacMethodBinding.getKey(builder, methodSymbol, methodSymbol.type instanceof Type.MethodType methodType ? methodType : null, this.resolver);
+			JavacMethodBinding.getKey(builder, methodSymbol, methodSymbol.type instanceof Type.MethodType methodType ? methodType : null, null, this.resolver);
 			builder.append('#');
 			builder.append(this.variableSymbol.name);
 			// FIXME: is it possible for the javac AST to contain multiple definitions of the same variable?
@@ -241,7 +241,7 @@ public abstract class JavacVariableBinding implements IVariableBinding {
 				if (!(method.type instanceof Type.MethodType methodType)) {
 					return null;
 				}
-				return this.resolver.bindings.getMethodBinding(methodType, method);
+				return this.resolver.bindings.getMethodBinding(methodType, method, null);
 			}
 			parentSymbol = parentSymbol.owner;
 		} while (parentSymbol != null);


### PR DESCRIPTION
- Add `parentType` to `JavacMethodBinding`
  - Currently only used when requesting the method binding through `typeBinding.getDeclaredMethods`
- Fix implementation of `JavacTypeBinding.getName` for wildcard types
- In `JavacMethodBinding.getKey()`, prefer using the return type from `methodType` to the return type from `methodSymbol`
- Use `JavacMethodBinding.parentType` in `getKey()`
  - Note that the erasure is intentionally not used.