### PR TITLE
Fix arg name inference for array types

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
@@ -252,6 +252,9 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 
 	private String resolveTypeName(com.sun.tools.javac.code.Type type, boolean binary) {
 		if (binary) {
+			if (type instanceof com.sun.tools.javac.code.Type.ArrayType arrayType) {
+				return resolveTypeName(arrayType.elemtype, binary) + "[]";
+			}
 			TypeSymbol sym = type.asElement();
 			if (sym != null) {
 				return sym.getQualifiedName().toString();


### PR DESCRIPTION
If you are extending a class and haven't implemented an abstract method that contains an argument that's an array type,
and the array element type is a well-known type such as `java.lang.Object`, this will now properly use the suggested name from JDT.

eg. parent signature `abstract public void useArray(Object[] arg1)`

child signature `public void useArray(Object[] o)`

`o` is the JDT suggested name for objects.