### PR TITLE
Fix problemId for lambda without return

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -1034,6 +1034,8 @@ public class JavacProblemConverter {
 				return IProblem.VoidMethodReturnsValue;
 			} else if ("compiler.misc.missing.ret.val".equals(diagnosticArg.getCode())) {
 				return IProblem.ShouldReturnValue;
+			} else if ("compiler.misc.incompatible.ret.type.in.lambda".equals(diagnosticArg.getCode())) {
+				return IProblem.ShouldReturnValue;
 			}
 		}
 		if (diagnostic instanceof JCDiagnostic jcDiagnostic && jcDiagnostic.getDiagnosticPosition() instanceof JCTree tree) {


### PR DESCRIPTION
- This also fixes the quickfix as a result

eg.

```java
Function<Integer, Integer> func = x -> {
    System.out.println(x);
};
```

becomes

```java
Function<Integer, Integer> func = x -> {
    System.out.println(x);
    return x;
};
```