### PR TITLE
Fix NPE when hovering at the keyword 'void'

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCodeSelector.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCodeSelector.java
@@ -605,6 +605,9 @@ public class DOMCodeSelector {
 	}
 
 	private IJavaElement[] findTypeInIndex(String packageName, String simpleName) throws JavaModelException {
+		if (simpleName == null) {
+			return new IJavaElement[0];
+		}
 		List<IType> indexMatch = new ArrayList<>();
 		TypeNameMatchRequestor requestor = new TypeNameMatchRequestor() {
 			@Override


### PR DESCRIPTION
When hovering over the keyword `void` at the context like `public static void main(...)`, it throws NPE.

```
!MESSAGE Unexpected runtime error while computing a text hover
!STACK 0
java.lang.NullPointerException: Cannot invoke "String.toCharArray()" because "simpleName" is null
	at org.eclipse.jdt.internal.codeassist.DOMCodeSelector.findTypeInIndex(DOMCodeSelector.java:622)
	at org.eclipse.jdt.internal.codeassist.DOMCodeSelector.codeSelect(DOMCodeSelector.java:409)
	at org.eclipse.jdt.internal.core.CompilationUnit.codeSelect(CompilationUnit.java:526)
	at org.eclipse.jdt.internal.core.CompilationUnit.codeSelect(CompilationUnit.java:518)
	at org.eclipse.jdt.internal.ui.text.java.hover.AbstractJavaEditorTextHover.getJavaElementsAt(AbstractJavaEditorTextHover.java:121)
	at org.eclipse.jdt.internal.ui.text.java.hover.JavadocHover.lambda$0(JavadocHover.java:713)
	at org.eclipse.jdt.internal.core.JavaModelManager.cacheZipFiles(JavaModelManager.java:5762)
	at org.eclipse.jdt.internal.core.JavaModelManager.callReadOnly(JavaModelManager.java:5751)
	at org.eclipse.jdt.core.JavaCore.callReadOnly(JavaCore.java:6180)
	at org.eclipse.jdt.internal.ui.text.java.hover.JavadocHover.internalGetHoverInfo(JavadocHover.java:713)
	at org.eclipse.jdt.internal.ui.text.java.hover.JavadocHover.getHoverInfo2(JavadocHover.java:709)
	at org.eclipse.jdt.internal.ui.text.java.hover.BestMatchHover.getHoverInfo2(BestMatchHover.java:163)
	at org.eclipse.jdt.internal.ui.text.java.hover.BestMatchHover.getHoverInfo2(BestMatchHover.java:130)
	at org.eclipse.jdt.internal.ui.text.java.hover.JavaEditorTextHoverProxy.getHoverInfo2(JavaEditorTextHoverProxy.java:89)
	at org.eclipse.jface.text.TextViewerHoverManager$1.run(TextViewerHoverManager.java:155)
```

```
!MESSAGE Error computing hover
!STACK 0
java.lang.NullPointerException: Cannot invoke "String.toCharArray()" because "simpleName" is null
	at org.eclipse.jdt.internal.codeassist.DOMCodeSelector.findTypeInIndex(DOMCodeSelector.java:619)
	at org.eclipse.jdt.internal.codeassist.DOMCodeSelector.codeSelect(DOMCodeSelector.java:409)
	at org.eclipse.jdt.internal.core.CompilationUnit.codeSelect(CompilationUnit.java:526)
	at org.eclipse.jdt.internal.core.CompilationUnit.codeSelect(CompilationUnit.java:518)
	at org.eclipse.jdt.ls.core.internal.JDTUtils.findElementsAtSelection(JDTUtils.java:1042)
	at org.eclipse.jdt.ls.core.internal.HoverInfoProvider.computeHover(HoverInfoProvider.java:101)
	at org.eclipse.jdt.ls.core.internal.handlers.HoverHandler.computeHover(HoverHandler.java:57)
	at org.eclipse.jdt.ls.core.internal.handlers.HoverHandler.hover(HoverHandler.java:43)
	at org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer.lambda$5(JDTLanguageServer.java:654)
	at org.eclipse.jdt.ls.core.internal.BaseJDTLanguageServer.lambda$0(BaseJDTLanguageServer.java:87)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:690)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:527)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1458)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2034)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:189)
```