### PR TITLE
Use absolute path when parsing a file in a project

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
@@ -35,7 +35,9 @@ import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.ToolProvider;
 
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
@@ -568,7 +570,18 @@ public class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 		var fileManager = (JavacFileManager)context.get(JavaFileManager.class);
 		List<JavaFileObject> fileObjects = new ArrayList<>(); // we need an ordered list of them
 		for (var sourceUnit : sourceUnits) {
-			File unitFile = new File(new String(sourceUnit.getFileName()));
+			File unitFile;
+			if (javaProject != null) {
+				// path is relative to the workspace, make it absolute
+				IResource asResource = javaProject.getProject().getParent().findMember(new String(sourceUnit.getFileName()));
+				if (asResource != null) {
+					unitFile = asResource.getLocation().toFile();
+				} else {
+					unitFile = new File(new String(sourceUnit.getFileName()));
+				}
+			} else {
+				unitFile = new File(new String(sourceUnit.getFileName()));
+			}
 			Path sourceUnitPath;
 			if (!unitFile.getName().endsWith(".java") || sourceUnit.getFileName() == null || sourceUnit.getFileName().length == 0) {
 				sourceUnitPath = Path.of(new File("whatever.java").toURI());


### PR DESCRIPTION
We were passing the project-relative path of a file to javac when working with Java files in Java projects. The reason it was working before was because we were directly sending the file's contents to the compiler.

This change fixes an error marker I get when opening any module-info.java, where javac would complain that the file is not on the source path. This is because javac was told the file was located at `/src/module-info.java`, but the source path it got was correctly set to (eg.) `/home/davthomp/Projects/module-project/src`.