### PR TITLE
Various fixes in order to get lemminx compiling using the builder

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -834,6 +834,7 @@ public class JavacProblemConverter {
 			case "compiler.err.cant.infer.local.var.type" -> IProblem.VarLocalWithoutInitizalier;
 			case "compiler.err.array.and.varargs" -> IProblem.RedefinedArgument;
 			case "compiler.err.type.doesnt.take.params" -> IProblem.NonGenericType;
+			case "compiler.err.static.imp.only.classes.and.interfaces" -> IProblem.InvalidTypeForStaticImport;
 			default -> {
 				ILog.get().error("Could not convert diagnostic (" + diagnostic.getCode() + ")\n" + diagnostic);
 				yield 0;

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/UnusedProblemFactory.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/UnusedProblemFactory.java
@@ -50,7 +50,7 @@ public class UnusedProblemFactory {
 		this.problemFactory = problemFactory;
 		this.compilerOptions = compilerOptions;
 	}
-	
+
 	public UnusedProblemFactory(IProblemFactory problemFactory, Map<String, String> compilerOptions) {
 		this.problemFactory = problemFactory;
 		this.compilerOptions = new CompilerOptions(compilerOptions);
@@ -134,9 +134,9 @@ public class UnusedProblemFactory {
 				int column = (int) unit.getLineMap().getColumnNumber(startPos);
 				problem = problemFactory.createProblem(fileName,
 						IProblem.UnusedPrivateType, new String[] {
-							shortName	
+							shortName
 						}, new String[] {
-							shortName	
+							shortName
 						},
 						severity, startPos, endPos, line, column);
 			} else if (decl instanceof JCMethodDecl methodDecl) {
@@ -179,7 +179,7 @@ public class UnusedProblemFactory {
 						typeName, name
 					};
 				} else if (varSymbol.owner instanceof MethodSymbol methodSymbol) {
-					if (methodSymbol.params().indexOf(varSymbol) >= 0) {
+					if (methodSymbol.type != null && methodSymbol.params().indexOf(varSymbol) >= 0) {
 						problemId = IProblem.ArgumentIsNeverUsed;
 					} else {
 						problemId = IProblem.LocalVariableIsNeverUsed;


### PR DESCRIPTION
- Port over the relative -> absolute path conversion from the JavacCompilationUnitResolver
- Add a logging statement for when the compilation crashes
- Add a null guard to prevent compilation from crashing
- Add an error id conversion I encountered along the way