### PR TITLE
Install o.e.jdt.core.tests.model artifact

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
 					mvn install -DskipTests -Djava.io.tmpdir=$WORKSPACE/tmp \
 						-Dtycho.buildqualifier.format="'z'yyyyMMdd-HHmm" \
 						-Pp2-repo \
-						-pl org.eclipse.jdt.core,org.eclipse.jdt.core.javac,repository
+						-pl org.eclipse.jdt.core,org.eclipse.jdt.core.javac,org.eclipse.jdt.core.tests.model,repository
 
 					mvn verify --batch-mode -f org.eclipse.jdt.core.tests.javac \
 						--fail-at-end -Ptest-on-javase-23 -Pbree-libs \


### PR DESCRIPTION
Should make tests run with locally built artifacts and not with I-build ones.