### PR TITLE
Problem range for `IProblem.AbstractServiceImplementation`

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -308,7 +308,7 @@ public class JavacProblemConverter {
 						&& diagnosticPath.getParentPath() != null
 						&& diagnosticPath.getParentPath().getLeaf() instanceof JCMethodDecl methodDecl) {
 					return getPositionByNodeRangeOnly(jcDiagnostic, methodDecl.getReturnType());
-				} else if (problemId == IProblem.ProviderMethodOrConstructorRequiredForServiceImpl) {
+				} else if (problemId == IProblem.ProviderMethodOrConstructorRequiredForServiceImpl || problemId == IProblem.AbstractServiceImplementation) {
 					return getPositionByNodeRangeOnly(jcDiagnostic, (JCTree)diagnosticPath.getLeaf());
 				} else if (problemId == IProblem.SwitchExpressionsYieldMissingDefaultCase
 						&& diagnosticPath.getLeaf() instanceof JCTree.JCSwitchExpression switchExpr) {


### PR DESCRIPTION
~~- progress is currently hampered by https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator/pull/729, I get a stacktrace that that PR should fix (classcast from within javac)~~

This PR used to contain way more fixes, but those have already been mostly merged.

Now it just fixes the problem range for `IProblem.AbstractServiceImplementation`.

This PR should introduce no new failures or passes in the test suite.