### PR TITLE
Enable lombok annotation processing when parsing DOM for workingcopy

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
@@ -33,6 +33,7 @@ import javax.tools.Diagnostic;
 import javax.tools.DiagnosticListener;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
 import org.eclipse.core.resources.IResource;
@@ -595,7 +596,7 @@ public class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 
 
 		JCCompilationUnit javacCompilationUnit = null;
-		Iterable<String> options = Arrays.asList("-proc:none"); // disable annotation processing in the parser.
+		Iterable<String> options = configureAPIfNecessary(fileManager) ? null : Arrays.asList("-proc:none");
 		JavacTask task = ((JavacTool)compiler).getTask(null, fileManager, null /* already added to context */, options, List.of() /* already set */, fileObjects, context);
 		{
 			// don't know yet a better way to ensure those necessary flags get configured
@@ -923,4 +924,47 @@ public class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 		};
 	}
 
+	private boolean configureAPIfNecessary(JavacFileManager fileManager) {
+		Iterable<? extends File> apPaths = fileManager.getLocation(StandardLocation.ANNOTATION_PROCESSOR_PATH);
+		if (apPaths != null) {
+			return true;
+		}
+
+		Iterable<? extends File> apModulePaths = fileManager.getLocation(StandardLocation.ANNOTATION_PROCESSOR_MODULE_PATH);
+		if (apModulePaths != null) {
+			return true;
+		}
+
+		Iterable<? extends File> classPaths = fileManager.getLocation(StandardLocation.CLASS_PATH);
+		if (classPaths != null) {
+			for(File cp : classPaths) {
+				String fileName = cp.getName();
+				if (fileName != null && fileName.startsWith("lombok") && fileName.endsWith(".jar")) {
+					try {
+						fileManager.setLocation(StandardLocation.ANNOTATION_PROCESSOR_PATH, List.of(cp));
+						return true;
+					} catch (IOException ex) {
+						ILog.get().error(ex.getMessage(), ex);
+					}
+				}
+			}
+		}
+
+		Iterable<? extends File> modulePaths = fileManager.getLocation(StandardLocation.MODULE_PATH);
+		if (modulePaths != null) {
+			for(File mp : modulePaths) {
+				String fileName = mp.getName();
+				if (fileName != null && fileName.startsWith("lombok") && fileName.endsWith(".jar")) {
+					try {
+						fileManager.setLocation(StandardLocation.ANNOTATION_PROCESSOR_MODULE_PATH, List.of(mp));
+						return true;
+					} catch (IOException ex) {
+						ILog.get().error(ex.getMessage(), ex);
+					}
+				}
+			}
+		}
+
+		return false;
+	}
 }


### PR DESCRIPTION
Currently JavaBuilder supports the Lombok annotation compilation well, but the DOM AST parser (JavacCompilationUnitResolver) does not. When you open a Java file with Lombok annotation, the DOM parser cannot find the generated lombok methods and report errors.

![image](https://github.com/user-attachments/assets/b774fd08-69d3-494b-bc17-64d169c05732)

Previously, we disabled the annotation processing in the DOM parser because most annotation processors will generate new source files based on current file's annotations, which could lead to unwanted source files regeneration when you just open an annotation file. This experience is bad so I just disable it in the DOM parser by default. And we let the JavaBuilder handle the annotation processing instead. (This is also the same behavior as ECJ, which handle the APT generation in build job only.)

However, in the case of Lombok, it manipulates current file's AST and inject additional code into current file. It's necessary to enable annotation processing when parsing the DOM of current file; otherwise, it cannot find those generated code.