### PR TITLE
Map error for diamond op on non generic type

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -996,6 +996,7 @@ public class JavacProblemConverter {
 			case "compiler.err.not.exhaustive" -> IProblem.SwitchExpressionsYieldMissingDefaultCase;
 			case "compiler.err.switch.expression.empty" -> IProblem.SwitchExpressionsYieldMissingDefaultCase;
 			case "compiler.err.return.outside.switch.expression" -> IProblem.SwitchExpressionsReturnWithinSwitchExpression;
+			case "compiler.err.cant.apply.diamond.1" -> IProblem.NonGenericType;
 			default -> {
 				ILog.get().error("Could not convert diagnostic (" + diagnostic.getCode() + ")\n" + diagnostic);
 				yield 0;


### PR DESCRIPTION
eg.
```java
Object asdf = new Object<>();
```

Also fixes the quickfix to remove it.