### PR TITLE
Make bindings.isEqualTo() respect the spec

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacAnnotationBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacAnnotationBinding.java
@@ -96,7 +96,7 @@ public abstract class JavacAnnotationBinding implements IAnnotationBinding {
 
 	@Override
 	public boolean isEqualTo(IBinding binding) {
-		return binding instanceof JavacAnnotationBinding other && Objects.equals(this.annotation, other.annotation);
+		return binding instanceof IAnnotationBinding other && Objects.equals(getKey(), other.getKey());
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMemberValuePairBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMemberValuePairBinding.java
@@ -27,7 +27,7 @@ public abstract class JavacMemberValuePairBinding implements IMemberValuePairBin
 	public final JavacMethodBinding method;
 	public final Attribute value;
 	private final JavacBindingResolver resolver;
-
+	
 	public JavacMemberValuePairBinding(MethodSymbol key, Attribute value, JavacBindingResolver resolver) {
 		this.method = resolver.bindings.getMethodBinding(key.type.asMethodType(), key, null, true);
 		this.value = value;
@@ -90,8 +90,7 @@ public abstract class JavacMemberValuePairBinding implements IMemberValuePairBin
 
 	@Override
 	public boolean isEqualTo(IBinding binding) {
-		return binding instanceof JavacMemberValuePairBinding other && this.method.isEqualTo(other.method)
-			&& Objects.equals(this.value, other.value);
+		return binding instanceof IMemberValuePairBinding other && Objects.equals(this.getKey(), other.getKey());
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
@@ -373,9 +373,8 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 
 	@Override
 	public boolean isEqualTo(IBinding binding) {
-		return binding instanceof JavacMethodBinding other && //
-			Objects.equals(this.methodSymbol, other.methodSymbol) && //
-			Objects.equals(this.resolver, other.resolver);
+		return binding instanceof IMethodBinding other && //
+			Objects.equals(this.getKey(), other.getKey());
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacModuleBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacModuleBinding.java
@@ -41,10 +41,8 @@ import com.sun.tools.javac.tree.JCTree.JCModuleDecl;
 import com.sun.tools.javac.tree.JCTree.JCRequires;
 public abstract class JavacModuleBinding implements IModuleBinding {
 
-	private static final ITypeBinding[] NO_TYPE_ARGUMENTS = new ITypeBinding[0];
 	final JavacBindingResolver resolver;
 	public final ModuleSymbol moduleSymbol;
-	private final ModuleType moduleType;
 	private JCModuleDecl moduleDecl;
 
 	public JavacModuleBinding(final ModuleType moduleType, final JavacBindingResolver resolver) {
@@ -61,7 +59,6 @@ public abstract class JavacModuleBinding implements IModuleBinding {
 	}
 	
 	public JavacModuleBinding(final ModuleSymbol moduleSymbol, final ModuleType moduleType, JavacBindingResolver resolver) {
-		this.moduleType = moduleType;
 		this.moduleSymbol = moduleSymbol;
 		this.resolver = resolver;
 	}
@@ -111,9 +108,8 @@ public abstract class JavacModuleBinding implements IModuleBinding {
 
 	@Override
 	public boolean isEqualTo(IBinding binding) {
-		return binding instanceof JavacModuleBinding other && //
-				Objects.equals(this.moduleSymbol, other.moduleSymbol) && //
-				Objects.equals(this.resolver, other.resolver);
+		return binding instanceof IModuleBinding other && //
+				Objects.equals(this.getKey(), other.getKey());
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacPackageBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacPackageBinding.java
@@ -154,7 +154,7 @@ public abstract class JavacPackageBinding implements IPackageBinding {
 
 	@Override
 	public boolean isEqualTo(IBinding binding) {
-		return equals(binding);
+		return binding instanceof IPackageBinding other && Objects.equals(getKey(), other.getKey());
 	}
 	
 	@Override

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -407,9 +407,8 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 
 	@Override
 	public boolean isEqualTo(final IBinding binding) {
-		return binding instanceof final JavacTypeBinding other &&
-			Objects.equals(this.resolver, other.resolver) &&
-			Objects.equals(this.typeSymbol, other.typeSymbol);
+		return binding instanceof final ITypeBinding other &&
+			Objects.equals(this.getKey(), other.getKey());
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
@@ -188,8 +188,7 @@ public abstract class JavacVariableBinding implements IVariableBinding {
 	@Override
 	public boolean isEqualTo(IBinding binding) {
 		return binding instanceof JavacVariableBinding other && //
-			Objects.equals(this.variableSymbol, other.variableSymbol) && //
-			Objects.equals(this.resolver, other.resolver);
+			Objects.equals(this.getKey(), other.getKey());
 	}
 
 	@Override


### PR DESCRIPTION
and work with bindings coming from different resolvers