### PR TITLE
Fix AST conversion error when handling type in array dims

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -1727,6 +1727,13 @@ class JavacConverter {
 			}
 			return res;
 		}
+		if (javac instanceof JCTree.JCArrayTypeTree arrayTypeTree) {
+			Type type = convertToType(javac);
+			TypeLiteral res = this.ast.newTypeLiteral();
+			res.setType(type);
+			commonSettings(res, arrayTypeTree);
+			return res;
+		}
 		return null;
 	}
 


### PR DESCRIPTION
eg. preserve the `m[]` in the AST in the following case, (despite the fact that it's invalid), since javac does.

```java
int[] foo = new int[m[]];
```