### PR TITLE
Improve field completion (`name.|`)

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -767,6 +767,7 @@ public class JavacProblemConverter {
 			case "compiler.err.cant.ref.before.ctor.called" -> IProblem.InstanceFieldDuringConstructorInvocation; // TODO different according to target node
 			case "compiler.err.not.def.public.cant.access" -> IProblem.NotVisibleType; // TODO different according to target node
 			case "compiler.err.already.defined" -> IProblem.DuplicateMethod; // TODO different according to target node
+			case "compiler.warn.underscore.as.identifier" -> IProblem.IllegalUseOfUnderscoreAsAnIdentifier;
 			case "compiler.err.var.might.not.have.been.initialized" -> {
 				VarSymbol symbol = getDiagnosticArgumentByType(diagnostic, VarSymbol.class);
 				yield symbol.owner instanceof ClassSymbol ?
@@ -1072,6 +1073,7 @@ public class JavacProblemConverter {
 			case "compiler.err.too.many.modules" -> IProblem.ModuleRelated;
 			case "compiler.err.call.must.only.appear.in.ctor" -> IProblem.InvalidExplicitConstructorCall;
 			case "compiler.err.void.not.allowed.here" -> IProblem.ParameterMismatch;
+			case "compiler.err.abstract.cant.be.accessed.directly" -> IProblem.DirectInvocationOfAbstractMethod;
 			default -> {
 				ILog.get().error("Could not accurately convert diagnostic (" + diagnostic.getCode() + ")\n" + diagnostic);
 				if (diagnostic.getKind() == javax.tools.Diagnostic.Kind.ERROR && diagnostic.getCode().startsWith("compiler.err")) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionContext.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionContext.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.internal.codeassist;
 
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-
 import org.eclipse.jdt.core.CompletionContext;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.Signature;
@@ -57,6 +56,9 @@ class DOMCompletionContext extends CompletionContext {
 	public IJavaElement[] getVisibleElements(String typeSignature) {
 		return this.bindingsAcquirer.get() //
 			.filter(binding -> {
+				if (typeSignature == null) {
+					return binding instanceof IVariableBinding || binding instanceof IMethodBinding;
+				}
 				if (binding instanceof IVariableBinding variableBinding) {
 					return castCompatable(variableBinding.getType(),
 							typeSignature);
@@ -69,6 +71,7 @@ class DOMCompletionContext extends CompletionContext {
 				return false;
 			}) //
 			.map(binding -> binding.getJavaElement()) //
+			.filter(obj -> obj != null) // eg. ArrayList.getFirst() when working with a Java 8 project
 			.toArray(IJavaElement[]::new);
 	}
 


### PR DESCRIPTION
- Use bindings to build out a list of possible suggestions
- Handle access modifiers properly (`private`, `static`, `abstract`, ...)
  - Exclude members in grandparent types whose access was narrowed in
    parent types
- Fix completion preceeding another statement eg.

```java
{
  name.|
  Object myObject = null;
}
```
- Fix `super.to|`
- Prevent `super.|` and `super.to|` from suggesting methods that are
  abstract in the parent type

Fixes #891