### PR TITLE
Improve constructor completion

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -1423,9 +1423,6 @@ class JavacConverter {
 		if (javac instanceof JCNewClass newClass) {
 			ClassInstanceCreation res = this.ast.newClassInstanceCreation();
 			commonSettings(res, javac);
-			if( ERROR.equals(newClass.getIdentifier().toString())) {
-				return null;
-			}
 			if( this.ast.apiLevel != AST.JLS2_INTERNAL) {
 				res.setType(convertToType(newClass.getIdentifier()));
 			} else {

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -1333,7 +1333,7 @@ public class JavacProblemConverter {
 				if (path != null) {
 					path = path.getParentPath();
 				}
-				if (path.getLeaf() instanceof JCEnhancedForLoop) {
+				if (path != null && path.getLeaf() instanceof JCEnhancedForLoop) {
 					return IProblem.IncompatibleTypesInForeach;
 				}
 				while (path != null && path.getLeaf() instanceof JCExpression) {

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -219,7 +219,12 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 			}
 			IType candidate = null;
 			if(typeRoot instanceof ICompilationUnit tmp) {
-				tmp = tmp.findWorkingCopy(this.resolver.getWorkingCopyOwner());
+				{
+					ICompilationUnit wc = tmp.findWorkingCopy(this.resolver.getWorkingCopyOwner());
+					if (wc != null) {
+						tmp = wc;
+					}
+				}
 				String[] cleaned = cleanedUpName(this.type).split("\\$");
 				if( cleaned.length > 0 ) {
 					cleaned[0] = cleaned[0].substring(cleaned[0].lastIndexOf('.') + 1);
@@ -753,7 +758,9 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 			if (types != null && types.length > 0) {
 				builder.append("<");
 				for (var typeArgument : types) {
-					builder.append(typeArgument.getName());
+					if (typeArgument != null) {
+						builder.append(typeArgument.getName());
+					}
 				}
 				builder.append(">");
 			}


### PR DESCRIPTION
- recover `new ` in AST converter
- scan backwards for first non-whitespace character when performing AST
  search
- use type hierachy to build a list of potential constructors
  - This method is expensive but accurate
- suggest creating anonymous classes when completing constructors for interfaces
- always provide all constructors of current type to be bug compatible
  with existing CompletionEngine
- complete array constructors with just the type name
- Basic support for generic types: inserts diamond operator if applicable

Limitations:
- relevance numbers are not quite right
- generic types don't quite work properly

Closes #892