### PR TITLE
Really ignore compiler.warn.dangling.doc.comment

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -645,7 +645,7 @@ public class JavacProblemConverter {
 	public int toProblemId(Diagnostic<? extends JavaFileObject> diagnostic) {
 		String javacDiagnosticCode = diagnostic.getCode();
 		return switch (javacDiagnosticCode) {
-			case "compiler.warn.dangling.doc.comment" -> 0; // ignore
+			case "compiler.warn.dangling.doc.comment" -> -1; // ignore
 			case "compiler.err.expected" -> IProblem.ParsingErrorInsertTokenAfter;
 			case "compiler.err.expected2" -> IProblem.ParsingErrorInsertTokenBefore;
 			case "compiler.err.expected3" -> IProblem.ParsingErrorInsertToComplete;


### PR DESCRIPTION
At some point the problem id that get ignored changed from 0 to -1 but this warning code was missed in the conversion.
This saves a warning in every file with license header.