### PR TITLE
Fix JavadocConverter.toMethodRefParam errors

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavadocConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavadocConverter.java
@@ -916,14 +916,6 @@ class JavadocConverter {
 				super.preVisit(node);
 			}
 		});
-		if (jdtType.getStartPosition() + jdtType.getLength() < res.getStartPosition() + res.getLength()) {
-			if (segments.length > 1) {
-				String nameSegment = segments[segments.length - 1];
-				SimpleName name = this.ast.newSimpleName(nameSegment);
-				name.setSourceRange(this.javacConverter.rawText.lastIndexOf(nameSegment, range.endPosition()), nameSegment.length());
-				res.setName(name);
-			}
-		}
 		return res;
 	}
 }


### PR DESCRIPTION
Loading bigger projects leads to many:
```
java.lang.IllegalArgumentException: Invalid identifier : >boolean<
	at org.eclipse.jdt.core.dom.SimpleName.setIdentifier(SimpleName.java:242)
	at org.eclipse.jdt.core.dom.AST.newSimpleName(AST.java:2934)
	at org.eclipse.jdt.core.dom.JavadocConverter.toMethodRefParam(JavadocConverter.java:922)
```

Previous javacConverter.convertToType already has the SimpleName proper
when it's really a simple name. In the case of PrimitiveType it fixes
the error.
Note that for some reason the following triggers the problem:
```
https://github.com/see Object#wait(Object,
int)
```
while the single line doesn't:
```
https://github.com/see Object#wait(Object, int)
```
But in both cases this seems to be redundant and error prone conversion.