### PR TITLE
Improve completion in extends/implements

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -2904,7 +2904,9 @@ class JavacConverter {
 				// the name second segment is invalid
 				simpleName.delete();
 				return qualifierType;
-			} else { // lombok case
+			} else {
+				// lombok case
+				// or empty (eg `test.`)
 				simpleName.setSourceRange(qualifierType.getStartPosition(), 0);
 			}
 			if(qualifierType instanceof SimpleType simpleType && (ast.apiLevel() < AST.JLS8 || simpleType.annotations().isEmpty())) {
@@ -2913,7 +2915,7 @@ class JavacConverter {
 				parentName.setParent(null, null);
 				QualifiedName name = this.ast.newQualifiedName(simpleType.getName(), simpleName);
 				commonSettings(name, javac);
-				int length = name.getName().getStartPosition() + name.getName().getLength() - name.getStartPosition();
+				int length = simpleType.getName().getLength() + 1 + simpleName.getLength();
 				if (name.getStartPosition() >= 0) {
 					name.setSourceRange(name.getStartPosition(), Math.max(0, length));
 				}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -351,6 +351,12 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 				}
 			}
 
+			/*
+			 * TODO - this name 'n' might be something like  test0502.A$1
+			 * but the test suite expects test0502.A$182,
+			 * where 182 is the location in the source of the symbol.
+			 */
+			builder.append(n.toString().replace('.', '/'));
 			// This is a hack and will likely need to be enhanced
 			if (typeToBuild.tsym instanceof ClassSymbol classSymbol && !(classSymbol.type instanceof ErrorType) && classSymbol.owner instanceof PackageSymbol) {
 				JavaFileObject sourcefile = classSymbol.sourcefile;
@@ -363,17 +369,14 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 						// probably: uri is not a valid path
 					}
 					if (fileName != null && !fileName.startsWith(classSymbol.getSimpleName().toString())) {
-						builder.append(fileName.substring(0, fileName.indexOf(".java")));
-						builder.append("~");
+						// There are multiple top-level types in this file,
+						// inject 'FileName~' before the type name to show that this type came from `FileName.java`
+						// (eg. Lorg/eclipse/jdt/FileName~MyTopLevelType;)
+						int simpleNameIndex  = builder.lastIndexOf(classSymbol.getSimpleName().toString());
+						builder.insert(simpleNameIndex, fileName.substring(0, fileName.indexOf(".java")) + "~");
 					}
 				}
 			}
-			/*
-			 * TODO - this name 'n' might be something like  test0502.A$1
-			 * but the test suite expects test0502.A$182, 
-			 * where 182 is the location in the source of the symbol. 
-			 */
-			builder.append(n.toString().replace('.', '/'));
 
 
 			boolean b1 = typeToBuild.isParameterized();


### PR DESCRIPTION
- Change dom conversion logic to recover incomplete type names properly
- Restrict the suggested classes based on if they are a class or interface
- Do not suggest final classes
- Do not suggest the current class