### PR TITLE
Ignore 2 warnings without positions

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -646,6 +646,7 @@ public class JavacProblemConverter {
 		String javacDiagnosticCode = diagnostic.getCode();
 		return switch (javacDiagnosticCode) {
 			case "compiler.warn.dangling.doc.comment" -> -1; // ignore
+			case "compiler.note.removal.filename", "compiler.note.deprecated.plural.additional" -> -1; //ignore due to lack of position
 			case "compiler.err.expected" -> IProblem.ParsingErrorInsertTokenAfter;
 			case "compiler.err.expected2" -> IProblem.ParsingErrorInsertTokenBefore;
 			case "compiler.err.expected3" -> IProblem.ParsingErrorInsertToComplete;


### PR DESCRIPTION
These are compiler.note.removal.filename,
compiler.note.deprecated.plural.additional and the fact that they don't have position info in them makes them not suitable to create Problems for them.