### PR TITLE
Fix StringIndexOutOfBoundsException in Javadoc conversion

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -418,7 +418,7 @@ class JavacConverter {
 				}
 				// workaround: some types appear to not keep the trailing semicolon in source range
 				if (res instanceof Name || res instanceof FieldAccess || res instanceof SuperFieldAccess ) {
-					while (endPos > start && this.rawText.charAt(endPos - 1) == ';') {
+					while (endPos > start && this.rawText.length()>= endPos && this.rawText.charAt(endPos - 1) == ';') {
 						endPos--;
 					}
 				}
@@ -2965,6 +2965,9 @@ class JavacConverter {
 					commonSettings(res, jcArrayType);
 				} else {
 					int endPos = jcArrayType.getEndPosition(this.javacCompilationUnit.endPositions);
+					if (endPos == -1) {
+						endPos = jcArrayType.pos;
+					}
 					int startPos = jcArrayType.getStartPosition();
 					try {
 						String raw = this.rawText.substring(startPos, endPos);


### PR DESCRIPTION
Make sure that calling substring is done with acceptable values, values bigger than string length or negative ones are plain wrong.
```
!ENTRY org.eclipse.jdt.core 4 0 2024-10-31 11:45:52.859
!MESSAGE Failed to convert Javadoc
!STACK 0
java.lang.StringIndexOutOfBoundsException: Index 2912 out of bounds for
length 1736
```