### PR TITLE
Fix wrong unused import for throws javadoc

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/UnusedTreeScanner.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/UnusedTreeScanner.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 
 import com.sun.source.doctree.SeeTree;
+import com.sun.source.doctree.ThrowsTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.IdentifierTree;
@@ -301,6 +302,14 @@ public class UnusedTreeScanner<R, P> extends TreeScanner<R, P> {
 				}
 			}
 			return super.visitSee(node, p);
+		}
+		
+		@Override
+		public R visitThrows(ThrowsTree node, P p) {
+			if (node.getExceptionName() instanceof com.sun.tools.javac.tree.DCTree.DCReference ref) {
+						useImport(ref);
+			}
+			return super.visitThrows(node, p);
 		}
 
 		private void useImport(com.sun.tools.javac.tree.DCTree.DCReference ref) {


### PR DESCRIPTION
If a RuntimeException is documented with throws javadoc tag it doesn't have to be declared as throws in the code but can be documented with throws tags and is wrongly marked as unused in this case.