### PR TITLE
Do not generate false positive unused parameter warning

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/UnusedTreeScanner.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/UnusedTreeScanner.java
@@ -200,7 +200,7 @@ public class UnusedTreeScanner<R, P> extends TreeScanner<R, P> {
 			Symbol owner = variable.sym == null ? null : variable.sym.owner;
 			if (owner instanceof ClassSymbol) {
 				return !isSerialVersionConstant(variable) && (variable.getModifiers().flags & Flags.PRIVATE) != 0;
-			} else if (owner instanceof MethodSymbol) {
+			} else if (owner instanceof MethodSymbol method && !method.enclClass().isInterface() && !method.isAbstract() && method.getAnnotation(Override.class) == null) {
 				return true;
 			}
 		}


### PR DESCRIPTION
The following cases are fixed:
* Interface methods
* Abstract methods
* Methods marked with Override annotation