### PR TITLE
Error IDs for problems unique to javac

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -1081,6 +1081,10 @@ public class JavacProblemConverter {
 			case "compiler.err.abstract.cant.be.accessed.directly" -> IProblem.DirectInvocationOfAbstractMethod;
 			case "compiler.warn.annotation.method.not.found" -> IProblem.UndefinedAnnotationMember;
 			case "compiler.err.import.module.not.found" -> IProblem.UndefinedModule;
+			case "compiler.warn.possible.this.escape" -> JavacProblemIds.PossibleThisEscape;
+			case "compiler.warn.possible.this.escape.location" -> JavacProblemIds.PossibleThisEscapeLocation;
+			case "compiler.warn.possible.loss.of.precision" -> JavacProblemIds.PossibleLossOfPrescision;
+			case "compiler.warn.auxiliary.class.accessed.from.outside.of.its.source.file" -> JavacProblemIds.AuxiliaryClassAccessedOutsideItsSourceFile;
 			default -> {
 				ILog.get().error("Could not accurately convert diagnostic (" + diagnostic.getCode() + ")\n" + diagnostic);
 				if (diagnostic.getKind() == javax.tools.Diagnostic.Kind.ERROR && diagnostic.getCode().startsWith("compiler.err")) {

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemIds.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemIds.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.jdt.internal.javac;
+
+/**
+ * Constant IDs for problems that don't have a corresponding diagnostic in ECJ.
+ */
+public class JavacProblemIds {
+
+	private JavacProblemIds() {}
+
+	/// some large number, I chose this from the Wikipedia prime page for fun
+	private static final int BaseJavacProblemId = 39916801;
+
+	public static final int PossibleThisEscape = BaseJavacProblemId + 1;
+	public static final int PossibleThisEscapeLocation = BaseJavacProblemId + 2;
+	public static final int PossibleLossOfPrescision = BaseJavacProblemId + 3;
+	public static final int AuxiliaryClassAccessedOutsideItsSourceFile = BaseJavacProblemId + 4;
+
+}


### PR DESCRIPTION
This causes 6 regressions because 'possible this escape' is now reported.