### PR TITLE
No completion in strings, text blocks, comments, or Javadoc

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
@@ -292,6 +292,9 @@ public class DOMCompletionEngine implements Runnable {
 
 			checkCancelled();
 
+			if (context instanceof StringLiteral || context instanceof TextBlock || context instanceof Comment || context instanceof Javadoc) {
+				return;
+			}
 			if (context instanceof FieldAccess fieldAccess) {
 				statementLikeKeywords();
 
@@ -590,6 +593,9 @@ public class DOMCompletionEngine implements Runnable {
 					}
 					publishFromScope(specificCompletionBindings);
 				}
+				suggestDefaultCompletions = false;
+			}
+			if (context instanceof Javadoc) {
 				suggestDefaultCompletions = false;
 			}
 


### PR DESCRIPTION
- Javadoc will need to be revisited, but for now I turned off the default completion

Fixes #933