### PR TITLE
Improve completion for binary infix operator

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
@@ -20,37 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import org.eclipse.jdt.core.dom.ASTNode;
-import org.eclipse.jdt.core.dom.ArrayAccess;
-import org.eclipse.jdt.core.dom.ArrayInitializer;
-import org.eclipse.jdt.core.dom.AssertStatement;
-import org.eclipse.jdt.core.dom.Assignment;
-import org.eclipse.jdt.core.dom.CastExpression;
-import org.eclipse.jdt.core.dom.ClassInstanceCreation;
-import org.eclipse.jdt.core.dom.DoStatement;
-import org.eclipse.jdt.core.dom.Expression;
-import org.eclipse.jdt.core.dom.ForStatement;
-import org.eclipse.jdt.core.dom.IMemberValuePairBinding;
-import org.eclipse.jdt.core.dom.IMethodBinding;
-import org.eclipse.jdt.core.dom.ITypeBinding;
-import org.eclipse.jdt.core.dom.IfStatement;
-import org.eclipse.jdt.core.dom.InfixExpression;
-import org.eclipse.jdt.core.dom.InstanceofExpression;
-import org.eclipse.jdt.core.dom.Javadoc;
-import org.eclipse.jdt.core.dom.LambdaExpression;
-import org.eclipse.jdt.core.dom.MemberValuePair;
-import org.eclipse.jdt.core.dom.MethodDeclaration;
-import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.jdt.core.dom.Modifier;
-import org.eclipse.jdt.core.dom.Name;
-import org.eclipse.jdt.core.dom.PrefixExpression;
-import org.eclipse.jdt.core.dom.PrimitiveType;
-import org.eclipse.jdt.core.dom.ReturnStatement;
-import org.eclipse.jdt.core.dom.TypeParameter;
-import org.eclipse.jdt.core.dom.VariableDeclaration;
-import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
-import org.eclipse.jdt.core.dom.WhileStatement;
+import org.eclipse.jdt.core.dom.*;
 import org.eclipse.jdt.internal.codeassist.impl.AssistOptions;
 
 /**
@@ -81,7 +51,8 @@ public class ExpectedTypes {
 
 		ASTNode parent =
 				this.node instanceof VariableDeclarationFragment
-				|| this.node instanceof MethodInvocation ?
+				|| this.node instanceof MethodInvocation
+				|| this.node instanceof InfixExpression ?
 				this.node : this.node.getParent();
 		// default filter
 		this.expectedTypesFilters = Set.of(TypeFilter.SUBTYPE);


### PR DESCRIPTION
In order to accomplish this,I have changed the logic for adjusting the offset used for the node search.

This causes some regressions:
  - A few cases where the test expects the AST not to be recovered but javac does recover it (eg. `org.eclipse.jdt.core.tests.model.CompletionTests_1_5.test0197`)
  - `@|` in Javadoc is not handled. Before it got no completion due to not finding the correct node, but now it gets default completion, which causes some regressions. I'll fix these when dealing with `@|` properly
  - The test cases sometimes expect the current class to be suggested in `new |` completion even when the type doesn't match, but sometimes they don't. I'll need to investigate further