### PR TITLE
Reduce processing using -implicit:none

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
@@ -70,6 +70,7 @@ import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.JavaProject;
 import org.eclipse.jdt.internal.core.dom.ICompilationUnitResolver;
 import org.eclipse.jdt.internal.core.util.BindingKeyParser;
+import org.eclipse.jdt.internal.javac.CachingJDKPlatformArguments;
 import org.eclipse.jdt.internal.javac.CachingJarsJavaFileManager;
 import org.eclipse.jdt.internal.javac.JavacProblemConverter;
 import org.eclipse.jdt.internal.javac.JavacUtils;
@@ -565,6 +566,7 @@ public class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 		var compiler = ToolProvider.getSystemJavaCompiler();
 		Context context = new Context();
 		CachingJarsJavaFileManager.preRegister(context);
+		CachingJDKPlatformArguments.preRegister(context);
 		Map<org.eclipse.jdt.internal.compiler.env.ICompilationUnit, CompilationUnit> result = new HashMap<>(sourceUnits.length, 1.f);
 		Map<JavaFileObject, CompilationUnit> filesToUnits = new HashMap<>();
 		final UnusedProblemFactory unusedProblemFactory = new UnusedProblemFactory(new DefaultProblemFactory(), compilerOptions);

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacCompiler.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacCompiler.java
@@ -50,6 +50,7 @@ import com.sun.tools.javac.api.MultiTaskListener;
 import com.sun.tools.javac.comp.AttrContext;
 import com.sun.tools.javac.comp.CompileStates.CompileState;
 import com.sun.tools.javac.comp.Env;
+import com.sun.tools.javac.file.CacheFSInfo;
 import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
@@ -105,6 +106,7 @@ public class JavacCompiler extends Compiler {
 		for (Entry<IContainer, List<ICompilationUnit>> outputSourceSet : outputSourceMapping.entrySet()) {
 
 			Context javacContext = new Context();
+			CacheFSInfo.preRegister(javacContext);
 			JavacProblemConverter problemConverter = new JavacProblemConverter(this.compilerConfig.compilerOptions(), javacContext);
 			javacContext.put(DiagnosticListener.class, diagnostic -> {
 				if (diagnostic.getSource() instanceof JavaFileObject fileObject) {
@@ -153,7 +155,7 @@ public class JavacCompiler extends Compiler {
 						this.isInGeneration = true;
 						super.generate(queue, results);
 					} catch (Throwable ex) {
-						// TODO error handling
+						ILog.get().error(ex.getMessage(), ex);
 					} finally {
 						this.isInGeneration = false;
 					}
@@ -164,7 +166,7 @@ public class JavacCompiler extends Compiler {
 					try {
 						super.desugar(env, results);
 					} catch (Throwable ex) {
-						// TODO error handling
+						ILog.get().error(ex.getMessage(), ex);
 					}
 				}
 

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacUtils.java
@@ -99,6 +99,7 @@ public class JavacUtils {
 	private static void configureOptions(IJavaProject javaProject, Context context, Map<String, String> compilerOptions, String addExports) {
 		boolean nineOrLater = false;
 		Options options = Options.instance(context);
+		options.put(Option.IMPLICIT, "none");
 		options.put("allowStringFolding", Boolean.FALSE.toString());
 		final Version complianceVersion;
 		String compliance = compilerOptions.get(CompilerOptions.OPTION_Compliance);
@@ -110,7 +111,6 @@ public class JavacUtils {
 			&& compliance != null && !compliance.isEmpty()) {
 			complianceVersion = Version.parse(compliance);
 			options.put(Option.RELEASE, compliance);
-			CachingJDKPlatformArguments.preRegister(context);
 			nineOrLater = complianceVersion.compareTo(Version.parse("9")) >= 0;
 		} else {
 			String source = compilerOptions.get(CompilerOptions.OPTION_Source);
@@ -158,13 +158,12 @@ public class JavacUtils {
 		}
 		options.put(Option.XLINT, Boolean.toString(true));
 		options.put(Option.XLINT_CUSTOM, "all");
-		options.put(Option.XDOCLINT, Boolean.toString(true));
-		options.put(Option.XDOCLINT_CUSTOM, "all");
-		if (addExports != null && !addExports.isBlank()) {
-			options.put(Option.ADD_EXPORTS, addExports);
-		}
 		if (JavaCore.ENABLED.equals(compilerOptions.get(JavaCore.COMPILER_DOC_COMMENT_SUPPORT))) {
 			options.put(Option.XDOCLINT, Boolean.toString(true));
+			options.put(Option.XDOCLINT_CUSTOM, "all");
+		}
+		if (addExports != null && !addExports.isBlank()) {
+			options.put(Option.ADD_EXPORTS, addExports);
 		}
 		if (nineOrLater && !options.isSet(Option.RELEASE) && javaProject instanceof JavaProject javaProjectImpl) {
 			try {


### PR DESCRIPTION
* Also do not share the Platform filemanager with build (a bit more isolation)
* a few other optimization to save CPU on irrelevant operations