### PR TITLE
If outside the double quotes of a string literal, use the parent as the completion context

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
@@ -297,6 +297,8 @@ public class DOMCompletionEngine implements Runnable {
 					}
 					completeAfter = this.cuBuffer.getText(cursor, this.offset - cursor);
 				}
+			} else if (this.toComplete instanceof StringLiteral stringLiteral && (this.offset <= stringLiteral.getStartPosition() || stringLiteral.getStartPosition() + stringLiteral.getLength() <= this.offset)) {
+				context = stringLiteral.getParent();
 			}
 			this.prefix = completeAfter;
 			this.qualifiedPrefix = this.prefix;


### PR DESCRIPTION
eg. complete `myString` in the following case:

```java
public class Main {

  public static void main(String... args) {
    String myString = "hi";
    System.out.println(|"hello");
  }

}
```

Fixes #966