### PR TITLE
Suggest creating a new lambda when a funcitonal interface is needed

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -837,6 +837,9 @@ public class JavacBindingResolver extends BindingResolver {
 				return res;
 			}
 		}
+		if (sym instanceof MethodSymbol && sym.type instanceof MethodType) {
+			return (IMethodBinding)this.bindings.getBinding(sym, sym.type);
+		}
 		return null;
 	}
 


### PR DESCRIPTION
- many fixes to parameter completion
- implementation note:

given the following code snippet:

```
myMethod(12, , );
```

there are broken ast nodes for the 2nd and 3rd argument. I use these nodes to help build completion when completing the 2nd and 3rd argument, since if the broken nodes didn't exist it would be really difficult to figure out which argument is being completed.