### PR TITLE
Revert "Fix error popups when class extends itself"

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -157,9 +157,6 @@ public class JavacBindingResolver extends BindingResolver {
 		}
 
 		public JavacMethodBinding getMethodBinding(MethodType methodType, MethodSymbol methodSymbol, com.sun.tools.javac.code.Type parentType, boolean isDeclaration) {
-			if (methodSymbol.owner == null || methodSymbol.owner.type == com.sun.tools.javac.code.Type.noType) {
-				return null;
-			}
 			JavacMethodBinding newInstance = new JavacMethodBinding(methodType, methodSymbol, parentType, JavacBindingResolver.this, false, isDeclaration) { };
 			return insertAndReturn(newInstance);
 		}
@@ -332,7 +329,7 @@ public class JavacBindingResolver extends BindingResolver {
 		//
 		private Map<String, JavacVariableBinding> variableBindings = new HashMap<>();
 		public JavacVariableBinding getVariableBinding(VarSymbol varSymbol) {
-			if (varSymbol == null || varSymbol.owner == null || varSymbol.owner.type == com.sun.tools.javac.code.Type.noType) {
+			if (varSymbol == null) {
 				return null;
 			}
 			JavacVariableBinding newInstance = new JavacVariableBinding(varSymbol, JavacBindingResolver.this) { };
@@ -360,8 +357,8 @@ public class JavacBindingResolver extends BindingResolver {
 			if (recoveredSymbol != null) {
 				return getBinding(recoveredSymbol, recoveredSymbol.type);
 			}
-			if (type instanceof ErrorType) {
-				if (type != null && type.getOriginalType() instanceof MethodType missingMethodType) {
+			if (type instanceof ErrorType || owner.owner == null || owner.owner.type == com.sun.tools.javac.code.Type.noType) {
+				if (type.getOriginalType() instanceof MethodType missingMethodType) {
 					return getErrorMethodBinding(missingMethodType, owner);
 				}
 			}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/ProceedOnErrorGen.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/ProceedOnErrorGen.java
@@ -13,10 +13,10 @@ package org.eclipse.jdt.internal.javac;
 import static com.sun.tools.javac.jvm.ByteCodes.athrow;
 
 import com.sun.tools.javac.code.Kinds.Kind;
-import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.ErrorType;
 import com.sun.tools.javac.comp.Attr;
 import com.sun.tools.javac.jvm.Gen;
+import com.sun.tools.javac.tree.TreeMaker;
 import com.sun.tools.javac.tree.JCTree.JCArrayAccess;
 import com.sun.tools.javac.tree.JCTree.JCAssign;
 import com.sun.tools.javac.tree.JCTree.JCErroneous;
@@ -27,7 +27,6 @@ import com.sun.tools.javac.tree.JCTree.JCInstanceOf;
 import com.sun.tools.javac.tree.JCTree.JCLiteral;
 import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
 import com.sun.tools.javac.tree.JCTree.JCNewClass;
-import com.sun.tools.javac.tree.TreeMaker;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.Names;
@@ -94,7 +93,7 @@ public class ProceedOnErrorGen extends Gen {
 
 	@Override
 	public void visitApply(JCMethodInvocation tree) {
-		if (tree.type.isErroneous() || !(tree.meth.type instanceof Type.MethodType)) {
+		if (tree.type.isErroneous()) {
 			visitErroneous(null);
 		} else {
 			super.visitApply(tree);
@@ -112,7 +111,7 @@ public class ProceedOnErrorGen extends Gen {
 
 	@Override
 	public void visitExec(JCExpressionStatement tree) {
-		if (tree.expr == null || tree.expr instanceof JCErroneous || tree.expr.type.isErroneous() || tree.expr.type instanceof Type.UnknownType) {
+		if (tree.expr == null || tree.expr instanceof JCErroneous || tree.expr.type.isErroneous()) {
 			visitErroneous(null);
 		} else {
 			super.visitExec(tree);

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/ProceedOnErrorTransTypes.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/ProceedOnErrorTransTypes.java
@@ -12,13 +12,9 @@ package org.eclipse.jdt.internal.javac;
 
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
-import com.sun.tools.javac.code.Type.ClassType;
-import com.sun.tools.javac.code.Type.ErrorType;
 import com.sun.tools.javac.comp.TransTypes;
-import com.sun.tools.javac.tree.JCTree.JCClassDecl;
-import com.sun.tools.javac.tree.JCTree.JCIdent;
-import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
 import com.sun.tools.javac.tree.TreeInfo;
+import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Context.Factory;
 
@@ -41,31 +37,9 @@ public class ProceedOnErrorTransTypes extends TransTypes {
 		Symbol meth = TreeInfo.symbol(tree.meth);
 		if (!(meth.baseSymbol() instanceof MethodSymbol)) {
 			//workaround: guard against ClassCastException when referencing non existing member
-			result = tree;
 			return;
 		}
 		super.visitApply(tree);
-	}
-	
-	@Override
-	public void visitClassDef(JCClassDecl tree) {
-		if (tree.sym.type.isErroneous() && tree.sym.type instanceof ErrorType errorType) {
-			// HACK: likely a cyclic dependency chain. Remove the inheritance and replace the symbol's type with a boring one.
-			tree.extending = null;
-			ClassType classType = new ClassType(errorType.getEnclosingType(), com.sun.tools.javac.util.List.nil(), tree.sym);
-			tree.sym.type = classType;
-			tree.setType(classType);
-		}
-		super.visitClassDef(tree);
-	}
-	
-	@Override
-	public void visitIdent(JCIdent tree) {
-		if (tree.sym.type.getEnclosingType() == null) {
-			result = tree;
-			return;
-		}
-		super.visitIdent(tree);
 	}
 
 }


### PR DESCRIPTION
Reverts eclipse-jdtls/eclipse-jdt-core-incubator#978
It causes some false errors to be reported while building sprint-petclinic.