### PR TITLE
Single pass compilation even with multiple source folders

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacClassFile.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacClassFile.java
@@ -19,11 +19,11 @@ import java.nio.file.Files;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.internal.compiler.ClassFile;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 
@@ -31,23 +31,27 @@ import com.sun.tools.javac.tree.JCTree.JCModuleDecl;
 
 public class JavacClassFile extends ClassFile {
 	private String fullName;
-	private IContainer outputDir;
 	private byte[] bytes = null;
-	private File proxyFile = null;
+	private final File proxyFile;
+	private final IFile outputFile;
 
-	public JavacClassFile(String qualifiedName, ClassFile enclosingClass, IContainer outputDir) {
+	public JavacClassFile(String qualifiedName, ClassFile enclosingClass, IContainer outputDir, java.nio.file.Path tempDir) {
 		this.fullName = qualifiedName;
 		this.isNestedType = enclosingClass != null;
 		this.enclosingClassFile = enclosingClass;
-		this.outputDir = outputDir;
+		var relativePath = new Path(this.fullName.replace('.', File.separatorChar)).addFileExtension(SuffixConstants.EXTENSION_class);
+		this.outputFile = outputDir.getFile(relativePath);
+		this.proxyFile = tempDir.resolve(relativePath.toPath()).toFile();
 	}
 
-	public JavacClassFile(JCModuleDecl moduleDecl, IContainer outputDir) {
+	public JavacClassFile(JCModuleDecl moduleDecl, IContainer outputDir, java.nio.file.Path tempDir) {
 		// TODO: moduleDecl probably needs to be used, but how?
 		this.fullName = "module-info";
 		this.isNestedType = false;
 		this.enclosingClassFile = null;
-		this.outputDir = outputDir;
+		var relativePath = new Path(this.fullName.replace('.', File.separatorChar)).addFileExtension(SuffixConstants.EXTENSION_class);
+		this.outputFile = outputDir.getFile(relativePath);
+		this.proxyFile = tempDir.resolve(relativePath.toPath()).toFile();
 	}
 
 	@Override
@@ -57,7 +61,6 @@ public class JavacClassFile extends ClassFile {
 		for (int i = 0; i < names.length; i++) {
 			compoundNames[i] = names[i].toCharArray();
 		}
-
 		return compoundNames;
 	}
 
@@ -70,90 +73,48 @@ public class JavacClassFile extends ClassFile {
 	@Override
 	public byte[] getBytes() {
 		if (this.bytes == null) {
-			File tempClassFile = this.getProxyTempClassFile();
-			if (tempClassFile == null || !tempClassFile.exists()) {
+			if (!this.proxyFile.exists()) {
 				this.bytes = new byte[0];
 			} else {
 				try {
-					this.bytes = Files.readAllBytes(tempClassFile.toPath());
+					this.bytes = Files.readAllBytes(this.proxyFile.toPath());
 				} catch (IOException e) {
 					this.bytes = new byte[0];
 				}
+				this.proxyFile.delete();
 			}
 		}
 
 		return this.bytes;
 	}
 
-	File getProxyTempClassFile() {
-		if (this.proxyFile == null) {
-			this.proxyFile = computeMappedTempClassFile(this.outputDir, this.fullName);
-		}
-
-		return this.proxyFile;
-	}
-
-	void deleteTempClassFile() {
-		File tempClassFile = this.getProxyTempClassFile();
-		if (tempClassFile != null && tempClassFile.exists()) {
-			tempClassFile.delete();
-		}
-	}
-
 	void deleteExpectedClassFile() {
-		IFile targetClassFile = computeExpectedClassFile(this.outputDir, this.fullName);
-		if (targetClassFile != null) {
-			try {
-				targetClassFile.delete(true, null);
-			} catch (CoreException e) {
-				// ignore
-			}
+		try {
+			this.outputFile.delete(true, null);
+		} catch (CoreException e) {
+			// ignore
 		}
 	}
 
-	/**
-	 * Returns the mapped temporary class file for the specified class symbol.
-	 */
-	public static File computeMappedTempClassFile(IContainer expectedOutputDir, String qualifiedClassName) {
-		if (expectedOutputDir != null) {
-			IPath baseOutputPath = getMappedTempOutput(expectedOutputDir);
-			String fileName = qualifiedClassName.replace('.', File.separatorChar);
-			IPath filePath = new Path(fileName);
-			return baseOutputPath.append(filePath.addFileExtension(SuffixConstants.EXTENSION_class)).toFile();
-		}
 
-		return null;
+
+	public void flushTempToOutput() {
+		try {
+			createFolder(outputFile.getParent());
+			outputFile.write(getBytes(), true, true, false, null);
+			this.proxyFile.delete();
+		} catch (CoreException e) {
+			ILog.get().error(e.getMessage(), e);
+		}
 	}
 
-	/**
-	 * Returns the expected class file for the specified class symbol.
-	 */
-	public static IFile computeExpectedClassFile(IContainer expectedOutputDir, String qualifiedClassName) {
-		if (expectedOutputDir != null) {
-			String fileName = qualifiedClassName.replace('.', File.separatorChar);
-			IPath filePath = new Path(fileName);
-			return expectedOutputDir.getFile(filePath.addFileExtension(SuffixConstants.EXTENSION_class));
+	private static IContainer createFolder(IContainer container) throws CoreException {
+		if (container instanceof IFolder folder && !folder.exists()) {
+			createFolder(folder.getParent());
+			folder.create(IResource.FORCE | IResource.DERIVED, true, null);
 		}
-
-		return null;
+		return container;
 	}
 
-	/**
-	 * The upstream ImageBuilder expects the Javac Compiler to return the
-	 * class file as bytes instead of writing it directly to the target
-	 * output directory. To prevent conflicts with the ImageBuilder, we
-	 * configure Javac to generate the class file in a temporary location.
-	 * This method returns the mapped temporary output location for the
-	 * specified output directory.
-	 */
-	public static IPath getMappedTempOutput(IContainer expectedOutput) {
-		IProject project = expectedOutput.getProject();
-		if (project == null) {
-			return expectedOutput.getRawLocation();
-		}
 
-		IPath workingLocation = project.getWorkingLocation(JavaCore.PLUGIN_ID);
-		String tempOutputName = expectedOutput.getName() + "_" + Integer.toHexString(expectedOutput.hashCode());
-		return workingLocation.append("javac/" + tempOutputName);
-	}
 }

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacUtils.java
@@ -238,9 +238,6 @@ public class JavacUtils {
 
 			if (output != null) {
 				fileManager.setLocation(StandardLocation.CLASS_OUTPUT, List.of(ensureDirExists(output)));
-			} else if (compilerConfig != null && !compilerConfig.sourceOutputMapping().isEmpty()) {
-				fileManager.setLocation(StandardLocation.CLASS_OUTPUT, compilerConfig.sourceOutputMapping().values().stream().distinct()
-						.map(container -> ensureDirExists(JavacClassFile.getMappedTempOutput(container).toFile())).toList());
 			} else if (javaProject.getProject() != null) {
 				IResource member = javaProject.getProject().getParent().findMember(javaProject.getOutputLocation());
 				if( member != null ) {


### PR DESCRIPTION
The Javac Builder does already sort the files so that all files that are requested by the compiler can be compiled together. Previously, there were grouped by output folder and multiple compilation steps were done, 1 for each folder, potentially duplicating a lot of work.
This PR builds all files at once.