### PR TITLE
Fix some inner class not being copied

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacClassFile.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacClassFile.java
@@ -30,7 +30,7 @@ import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import com.sun.tools.javac.tree.JCTree.JCModuleDecl;
 
 public class JavacClassFile extends ClassFile {
-	private String fullName;
+	final String fullName;
 	private byte[] bytes = null;
 	private final File proxyFile;
 	private final IFile outputFile;


### PR DESCRIPTION
In some cases (such as switch expressions), Javac generates some extra .class files of nested anonymous types. Those are only created duing the "generate" phase, and are not detected during "analyze"; so we add in the listener for Generate ability to record such newly generated classes.

Fixes https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator/issues/1014