### PR TITLE
Don't add import for `java.lang`

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
@@ -1521,7 +1521,7 @@ public class DOMCompletionEngine implements Runnable {
 		res.setRelevance(relevance);
 		if (parentType != null) {
 			// propose importing the type
-			res.setRequiredProposals(new CompletionProposal[] { toImportProposal(simpleName, signature) });
+			res.setRequiredProposals(new CompletionProposal[] { toImportProposal(simpleName, signature, type.getPackageFragment()) });
 		} else {
 			res.setRequiredProposals(new CompletionProposal[0]);
 		}
@@ -1701,10 +1701,11 @@ public class DOMCompletionEngine implements Runnable {
 		return res;
 	}
 
-	private CompletionProposal toImportProposal(char[] simpleName, char[] signature) {
+	private CompletionProposal toImportProposal(char[] simpleName, char[] signature, IPackageFragment packageFragment) {
 		InternalCompletionProposal res = new InternalCompletionProposal(CompletionProposal.TYPE_IMPORT, this.offset);
 		res.setName(simpleName);
 		res.setSignature(signature);
+		res.setPackageName(packageFragment.getElementName().toCharArray());
 		res.completionEngine = this.nestedEngine;
 		res.nameLookup = this.nameEnvironment.nameLookup;
 		return res;


### PR DESCRIPTION
When importing a type via completion, don't add an import for the type if it's from `java.lang`

A part of #1024