### PR TITLE
Revert "Ensure all parent nodes fully encompass their child nodes"

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
@@ -772,20 +772,11 @@ public class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 						@Override
 						public void postVisit(ASTNode node) { // fix some positions
 							if( node.getParent() != null ) {
-								int myStart = node.getStartPosition();
-								int myEnd = myStart + node.getLength();
-								int parentStart = node.getParent().getStartPosition();
-								int parentEnd = parentStart + node.getParent().getLength();
-								int newParentStart = parentStart;
-								int newParentEnd = parentEnd;
-								if( myStart >= 0 && myStart < parentStart) {
-									newParentStart = myStart;
-								}
-								if( myStart >= 0 && myEnd > parentEnd) {
-									newParentEnd = myEnd;
-								}
-								if( parentStart != newParentStart || parentEnd != newParentEnd) {
-									node.getParent().setSourceRange(newParentStart, newParentEnd - newParentStart);
+								if( node.getStartPosition() < node.getParent().getStartPosition()) {
+									int parentEnd = node.getParent().getStartPosition() + node.getParent().getLength();
+									if( node.getStartPosition() >= 0 ) {
+										node.getParent().setSourceRange(node.getStartPosition(), parentEnd - node.getStartPosition());
+									}
 								}
 							}
 						}


### PR DESCRIPTION
This reverts commit dd17d97223cf005373b6d60ec8a07c065edebb4e.