### PR TITLE
Keep cached filesystems uniniterruptible

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/ZipFileSystemProviderWithCache.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/ZipFileSystemProviderWithCache.java
@@ -111,20 +111,24 @@ public class ZipFileSystemProviderWithCache extends FileSystemProvider {
 			var res = delegate.newFileSystem(path, env);
 			this.cachedFilesystems.put(path, res);
 			this.lastModificationOfCache.put(res, lastMod);
-			try {
-				// workaround to make the underlying work of the ZipFileSystem
-				// resistant to thread abortion. Without it, the zips become
-				// useless when a consumer thread aborts
-				var zipFileSystemClass = res.getClass();
-				var chField = zipFileSystemClass.getDeclaredField("ch");
-				chField.setAccessible(true);
-				if (chField.get(res) instanceof FileChannelImpl fileChannel) {
-					fileChannel.setUninterruptible();
-				}
-			} catch (Exception ex) {
-				ILog.get().error(ex.getMessage(), ex);
-			}
+			makeFileSystemUninterruptible(res);
 			return res;
+		}
+	}
+
+	static void makeFileSystemUninterruptible(FileSystem res) {
+		try {
+			// workaround to make the underlying work of the ZipFileSystem
+			// resistant to thread abortion. Without it, the zips become
+			// useless when a consumer thread aborts
+			var zipFileSystemClass = res.getClass();
+			var chField = zipFileSystemClass.getDeclaredField("ch");
+			chField.setAccessible(true);
+			if (chField.get(res) instanceof FileChannelImpl fileChannel) {
+				fileChannel.setUninterruptible();
+			}
+		} catch (Exception ex) {
+			ILog.get().error(ex.getMessage(), ex);
 		}
 	}
 	


### PR DESCRIPTION
ZipFileSystem can have its underlying channel closed if a consuming thread was interrupted while reading (eg aborted hover). Override the fileManager so that the channel is not closed.