### PR TITLE
Do not double-propose types

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
@@ -643,6 +643,9 @@ public class DOMCompletionEngine implements Runnable {
 					ExtendsOrImplementsInfo extendsOrImplementsInfo = isInExtendsOrImplements(this.toComplete);
 					if (!this.requestor.isIgnored(CompletionProposal.TYPE_REF)) {
 						findTypes(completeAfter, typeMatchRule, null)
+							.filter(type -> {
+								return defaultCompletionBindings.stream().map(typeBinding -> typeBinding.getJavaElement()).noneMatch(elt -> type.equals(elt));
+							})
 							.filter(type -> this.pattern.matchesName(this.prefix.toCharArray(),
 									type.getElementName().toCharArray()))
 							.filter(type -> {


### PR DESCRIPTION
Sometimes, types were collected by the scrapeBindings method and the type search.
This PR prevents suggesting the type from the type search if it was already suggested through publishFromScope

Should fix ~10 test cases