### PR TITLE
Improve method and type key

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -363,7 +363,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 		}
 		if (typeToBuild instanceof Type.WildcardType wildcardType) {
 			if (wildcardType.isUnbound()) {
-				builder.append('*');
+				builder.append("+Ljava/lang/Object;");
 			} else if (wildcardType.isExtendsBound()) {
 				builder.append('+');
 				getKey(builder, wildcardType.getExtendsBound(), isLeaf, includeParameters, resolver);


### PR DESCRIPTION
* Also include the exception from @throws in JavacMethodBinding.getJavaElement() by reusing the existing matching IMethod
* for resolved Wildcards that are unbound, make it same as `extends java.lang.Object`)