### PR TITLE
Constructor invocation completion proposal improvements

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
@@ -158,12 +158,18 @@ public class ExpectedTypes {
 			} else {
 				// find the param
 				IMethodBinding methodBinding = messageSend.resolveMethodBinding();
-				if (this.node != parent && methodBinding != null) {
-					int i = messageSend.arguments().indexOf(this.node);
-					if (0 <= i && i < methodBinding.getParameterTypes().length) {
-						this.expectedTypes.add(methodBinding.getParameterTypes()[i]);
-					} else if (0 <= i && methodBinding.isVarargs()) {
-						this.expectedTypes.add(methodBinding.getParameterTypes()[methodBinding.getParameterTypes().length - 1]);
+				if (this.node != parent) {
+					ASTNode cursor = this.node;
+					while (cursor != null && cursor.getParent() != messageSend) {
+						cursor = cursor.getParent();
+					}
+					if (cursor != null && methodBinding != null) {
+						int i = messageSend.arguments().indexOf(cursor);
+						if (0 <= i && i < methodBinding.getParameterTypes().length) {
+							this.expectedTypes.add(methodBinding.getParameterTypes()[i]);
+						} else if (0 <= i && methodBinding.isVarargs()) {
+							this.expectedTypes.add(methodBinding.getParameterTypes()[methodBinding.getParameterTypes().length - 1]);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
- Use expected types to infer constructor type (instead of existing logic which duplicates the logic of expected types)
- Use `IType` and `IMethod` when creating constructor invocation proposals, to avoid needing to create bindings
- Handle suggesting the default constructor when an `IType` has no explicit constructors
- Modify the content of the completion proposals to match what's expected by the tests