### PR TITLE
Completion for `import module |;`

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -1080,6 +1080,7 @@ public class JavacProblemConverter {
 			case "compiler.err.void.not.allowed.here" -> IProblem.ParameterMismatch;
 			case "compiler.err.abstract.cant.be.accessed.directly" -> IProblem.DirectInvocationOfAbstractMethod;
 			case "compiler.warn.annotation.method.not.found" -> IProblem.UndefinedAnnotationMember;
+			case "compiler.err.import.module.not.found" -> IProblem.UndefinedModule;
 			default -> {
 				ILog.get().error("Could not accurately convert diagnostic (" + diagnostic.getCode() + ")\n" + diagnostic);
 				if (diagnostic.getKind() == javax.tools.Diagnostic.Kind.ERROR && diagnostic.getCode().startsWith("compiler.err")) {


### PR DESCRIPTION
This is new Java 23 syntax. This PR should make 6 new tests pass (mostly from the java 23 completion suite).

This PR also incorporates https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3479, I forget specifically why, but it's needed.

- Fixes to the javac AST converter
  - I did a hack in the converter to recover the following case, since javac doesn't handle it currently:

```java
import module

public class HelloWorld {
}
```

- Adjust module completion relevance based on if it's required by the current module