### PR TITLE
Do not create invalid JavacVariableBinding

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -97,6 +97,7 @@ import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.tree.JCTree.JCWildcard;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Names;
 
 /**
  * Deals with creation of binding model, using the <code>Symbol</code>s from Javac.
@@ -1221,7 +1222,9 @@ public class JavacBindingResolver extends BindingResolver {
 		if (this.converter.domToJavac.get(variable) instanceof JCVariableDecl decl) {
 			// the decl.type can be null when there are syntax errors
 			if ((decl.type != null && !decl.type.isErroneous()) || this.isRecoveringBindings()) {
-				return this.bindings.getVariableBinding(decl.sym);
+				if (decl.name != Names.instance(this.context).error) { // cannot recover if name is error
+					return this.bindings.getVariableBinding(decl.sym);
+				}
 			}
 		}
 		return null;

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -92,6 +92,7 @@ import com.sun.tools.javac.code.Type.TypeVar;
 import com.sun.tools.javac.code.Type.WildcardType;
 import com.sun.tools.javac.code.Types.FunctionDescriptorLookupError;
 import com.sun.tools.javac.util.Name;
+import com.sun.tools.javac.util.Names;
 
 public abstract class JavacTypeBinding implements ITypeBinding {
 
@@ -100,6 +101,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 	final JavacBindingResolver resolver;
 	public final TypeSymbol typeSymbol;
 	private final Types types;
+	private final Names names;
 	public final Type type;
 	private final boolean isGeneric; // only relevent for parameterized types
 	private boolean recovered = false;
@@ -115,6 +117,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 		this.type = this.isGeneric || type == null ? this.typeSymbol.type /*generic*/ : type /*specific instance*/;
 		this.resolver = resolver;
 		this.types = Types.instance(this.resolver.context);
+		this.names = Names.instance(this.resolver.context);
 		// TODO: consider getting rid of typeSymbol in constructor and always derive it from type
 	}
 
@@ -552,6 +555,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 		return StreamSupport.stream(this.typeSymbol.members().getSymbols().spliterator(), false)
 			.filter(VarSymbol.class::isInstance)
 			.map(VarSymbol.class::cast)
+			.filter(sym -> sym.name != this.names.error)
 			.map(this.resolver.bindings::getVariableBinding)
 			.toArray(IVariableBinding[]::new);
 	}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
@@ -1486,6 +1486,9 @@ public class DOMCompletionEngine implements Runnable {
 		}
 
 		Predicate<IBinding> accessFilter = binding -> {
+			if (binding == null) {
+				return false;
+			}
 			boolean field = binding instanceof IVariableBinding;
 			if (field) {
 				if (impossibleFields.contains(binding.getName())) {


### PR DESCRIPTION
when underlying VarSymbol is error