### PR TITLE
Ignore diagnostics without positions

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -648,7 +648,8 @@ public class JavacProblemConverter {
 		String javacDiagnosticCode = diagnostic.getCode();
 		return switch (javacDiagnosticCode) {
 			case "compiler.warn.dangling.doc.comment" -> -1; // ignore
-			case "compiler.note.removal.filename", "compiler.note.deprecated.plural.additional" -> -1; //ignore due to lack of position
+			case "compiler.note.removal.filename", "compiler.note.deprecated.plural.additional",
+				 "compiler.note.removal.plural.additional", "compiler.note.unchecked.filename" -> -1; // ignore due to lack of position
 			case "compiler.err.expected" -> IProblem.ParsingErrorInsertTokenAfter;
 			case "compiler.err.expected2" -> IProblem.ParsingErrorInsertTokenBefore;
 			case "compiler.err.expected3" -> IProblem.ParsingErrorInsertToComplete;


### PR DESCRIPTION
"compiler.note.removal.plural.additional",
"compiler.note.unchecked.filename" don't have positions thus are not usable in the ide.