### PR TITLE
Map one more varargs diagnostic

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -852,7 +852,7 @@ public class JavacProblemConverter {
 			case "compiler.err.cant.access" -> IProblem.NotAccessibleType;
 			case "compiler.err.var.not.initialized.in.default.constructor" -> IProblem.UninitializedBlankFinalField;
 			case "compiler.err.assert.as.identifier" -> IProblem.UseAssertAsAnIdentifier;
-			case "compiler.warn.unchecked.varargs.non.reifiable.type" -> IProblem.PotentialHeapPollutionFromVararg;
+			case "compiler.warn.unchecked.varargs.non.reifiable.type", "compiler.warn.varargs.unsafe.use.varargs.param" -> IProblem.PotentialHeapPollutionFromVararg;
 			case "compiler.err.var.might.already.be.assigned" -> IProblem.FinalFieldAssignment;
 			case "compiler.err.annotation.missing.default.value.1" -> IProblem.MissingValueForAnnotationMember;
 			case "compiler.warn.static.not.qualified.by.type" -> {


### PR DESCRIPTION
Cases like:
```
!ENTRY org.eclipse.jdt.core 4 0 2025-01-22 10:50:27.539
!MESSAGE Could not accurately convert diagnostic
(compiler.warn.varargs.unsafe.use.varargs.param)
/home/akurtakov/git/eclipse.platform.ui/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/list/ListDiffTest.java:148:
warning: [varargs] Varargs method could cause heap pollution from
non-reifiable varargs parameter differences
		return Diffs.createListDiff(differences);
```
should be properly mapped now.