### PR TITLE
Add api filters

### DIFF
--- a/org.eclipse.jdt.core/.settings/.api_filters
+++ b/org.eclipse.jdt.core/.settings/.api_filters
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.jdt.core" version="2">
+    <resource path="dom/org/eclipse/jdt/core/dom/AST.java" type="org.eclipse.jdt.core.dom.AST">
+        <filter comment="javac branch has bigger version" id="1141899266">
+            <message_arguments>
+                <message_argument value="3.41"/>
+                <message_argument value="3.42"/>
+                <message_argument value="getAllVersions()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="dom/org/eclipse/jdt/core/dom/AbstractTagElement.java" type="org.eclipse.jdt.core.dom.AbstractTagElement">
         <filter id="576725006">
             <message_arguments>
@@ -219,6 +228,15 @@
             <message_arguments>
                 <message_argument value="ASTNode"/>
                 <message_argument value="VariableDeclaration"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="model/org/eclipse/jdt/core/JavaCore.java" type="org.eclipse.jdt.core.JavaCore">
+        <filter comment="Javac branch has bigger version" id="1141899266">
+            <message_arguments>
+                <message_argument value="3.41"/>
+                <message_argument value="3.42"/>
+                <message_argument value="defaultRootModules(Iterable&lt;IPackageFragmentRoot&gt;, String)"/>
             </message_arguments>
         </filter>
     </resource>


### PR DESCRIPTION
In order to have javac branch with bigger version of jdt.core so it always overrides it during testing.