### PR TITLE
Tolerate CompletionFailure in JavacTypeBinding

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -418,7 +418,11 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 			try {
 				b2 = typeToBuild.tsym != null && typeToBuild.tsym.type != null && typeToBuild.tsym.type.isParameterized();
 			} catch( CompletionFailure cf1) {
-				throw new BindingKeyException(cf1);
+				if (resolver.isRecoveringBindings()) {
+					ILog.get().error(cf1.getMessage(), cf1);
+				} else {
+					throw new BindingKeyException(cf1);
+				}
 			}
 			if ((b1 || b2) && includeParameters) {
 				builder.append('<');


### PR DESCRIPTION
A previous fix has unveiled that some null bindings are sometimes returned unexpectedly. This is a consequence of CompletionFailure breaking the key computation.
While it's not clear what is the actual cause and best resolution for this case, it seems like it's still better to just ignore (and log) that to forward error and return a null binding.