### PR TITLE
Fix some bugs in completion type filtering

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
@@ -1455,6 +1455,8 @@ public class DOMCompletionEngine implements ICompletionEngine {
 					if (!this.requestor.isIgnored(CompletionProposal.TYPE_REF)) {
 						final Set<String> alreadySuggestedFqn = ConcurrentHashMap.newKeySet();
 						findTypes(completeAfter, typeMatchRule, null)
+							.filter(type -> this.pattern.matchesName(this.prefix.toCharArray(),
+									type.getElementName().toCharArray()))
 							.filter(type -> filterTypeBasedOnAccess(type, currentPackage, currentTypeBinding))
 							.filter(type -> {
 								for (var scrapedBinding : defaultCompletionBindings.all().toList()) {
@@ -1466,8 +1468,6 @@ public class DOMCompletionEngine implements ICompletionEngine {
 								}
 								return true;
 							})
-							.filter(type -> this.pattern.matchesName(this.prefix.toCharArray(),
-									type.getElementName().toCharArray()))
 							.filter(type -> {
 								return filterBasedOnExtendsOrImplementsInfo(type, extendsOrImplementsInfo);
 							})
@@ -1519,11 +1519,11 @@ public class DOMCompletionEngine implements ICompletionEngine {
 				return true;
 			}
 			if ((flags & Flags.AccProtected) != 0) {
-				// protected means `type` is an inner class
-				if (currentTypeBinding == null) {
+				// if `protected` is used correctly means `type` is an inner class
+				if (currentTypeBinding == null || type.getDeclaringType() == null) {
 					return false;
 				}
-				return findInSupers(currentTypeBinding, ((IType)type.getParent()).getKey());
+				return findInSupers(currentTypeBinding, type.getDeclaringType().getKey());
 			}
 			// private inner class
 			return false;
@@ -2289,7 +2289,7 @@ public class DOMCompletionEngine implements ICompletionEngine {
 					return false;
 				}
 			} else {
-				if (impossibleMethods.contains(binding.getName())) {
+				if (impossibleClasses.contains(binding.getName())) {
 					return false;
 				}
 			}


### PR DESCRIPTION
- Do prefix filtering first; string comparison should be fast compared to more involved operations
- Fix bad implementation of `protected` member classes; `getParent()` wasn't the right method to get the parent class of a member class
- Impossible classes filtering was wrong, it was checking methods
  instead