### PR TITLE
Fix `TryStatement` always marked as malformed by `JavacConverter`

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -2796,21 +2796,17 @@ class JavacConverter {
 			res.setFinally(convertBlock(javac.getFinallyBlock()));
 		}
 
-		if( this.ast.apiLevel >= AST.JLS8_INTERNAL) {
-			if( javac.getResources().size() > 0) {
-				Iterator<JCTree> it = javac.getResources().iterator();
-				while(it.hasNext()) {
-					ASTNode working = convertTryResource(it.next(), parent);
-					if( working instanceof VariableDeclarationExpression) {
-						res.resources().add(working);
-					} else if( this.ast.apiLevel >= AST.JLS9_INTERNAL && working instanceof Name){
-						res.resources().add(working);
-					} else {
-						res.setFlags(res.getFlags() | ASTNode.MALFORMED);
-					}
+		if( javac.getResources().size() > 0) {
+			Iterator<JCTree> it = javac.getResources().iterator();
+			while(it.hasNext()) {
+				ASTNode working = convertTryResource(it.next(), parent);
+				if( working instanceof VariableDeclarationExpression) {
+					res.resources().add(working);
+				} else if( this.ast.apiLevel >= AST.JLS9_INTERNAL && working instanceof Name){
+					res.resources().add(working);
+				} else {
+					res.setFlags(res.getFlags() | ASTNode.MALFORMED);
 				}
-			} else {
-				res.setFlags(res.getFlags() | ASTNode.MALFORMED);
 			}
 		}
 		javac.getCatches().stream().map(this::convertCatcher).forEach(res.catchClauses()::add);


### PR DESCRIPTION
Fixes:
`ASTConverterTest.test0113`
`ASTConverterTest.test0114`
`ASTConverterTest.test0115`

as well as tests for other Java versions

Note: we only need to accomodate Java >= 8 in the AST conversion process, since that's what upstream does now.