### PR TITLE
Fix source range for array types when the `[` is unicode escape

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -3040,6 +3040,9 @@ class JavacConverter {
 						String raw = this.rawText.substring(startPos, endPos);
 						int ordinalEnd = ordinalIndexOf(raw, "]", dims);
 						int ordinalStart = ordinalIndexOf(raw, "[", dims);
+						if (ordinalStart == -1) {
+							ordinalStart = ordinalIndexOf(raw, "\\u005b", dims);
+						}
 						if( ordinalEnd != -1 ) {
 							commonSettings(res, jcArrayType, ordinalEnd + 1, true);
 							if( this.ast.apiLevel >= AST.JLS8_INTERNAL ) {


### PR DESCRIPTION
eg. `MyType\u005b] myTypeArray = null;`

Fixes 4 tests:
`ASTConverterTest.test0266` and the versions for other Java compliances