### PR TITLE
Improve extends/implements completion

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.internal.codeassist.DOMCompletionUtil;
 import org.eclipse.jdt.internal.javac.dom.JavacAnnotationBinding;
 import org.eclipse.jdt.internal.javac.dom.JavacErrorMethodBinding;
+import org.eclipse.jdt.internal.javac.dom.JavacErrorTypeBinding;
 import org.eclipse.jdt.internal.javac.dom.JavacLambdaBinding;
 import org.eclipse.jdt.internal.javac.dom.JavacMemberValuePairBinding;
 import org.eclipse.jdt.internal.javac.dom.JavacMethodBinding;
@@ -69,6 +70,7 @@ import com.sun.tools.javac.code.Type.MethodType;
 import com.sun.tools.javac.code.Type.ModuleType;
 import com.sun.tools.javac.code.Type.PackageType;
 import com.sun.tools.javac.code.Type.TypeVar;
+import com.sun.tools.javac.code.Type.UnknownType;
 import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.tree.JCTree;
@@ -709,6 +711,9 @@ public class JavacBindingResolver extends BindingResolver {
 	ITypeBinding resolveType(TypeDeclaration type) {
 		resolve();
 		JCTree javacNode = this.converter.domToJavac.get(type);
+		if (javacNode instanceof JCClassDecl jcClassDecl && javacNode.type instanceof UnknownType && "<any?>".equals(javacNode.type.toString())) {
+			return new JavacErrorTypeBinding(javacNode.type, javacNode.type.tsym, true, JavacBindingResolver.this, jcClassDecl.sym);
+		}
 		if (javacNode instanceof JCClassDecl jcClassDecl && jcClassDecl.type != null) {
 			return this.bindings.getTypeBinding(jcClassDecl.type, true);
 		}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorTypeBinding.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.internal.javac.dom;
+
+import org.eclipse.jdt.core.dom.JavacBindingResolver;
+
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Symbol.TypeSymbol;
+import com.sun.tools.javac.code.Type;
+
+/**
+ * Represents a binding for a type that javac struggles to recover,
+ * for example a class with an empty `implements` or `extends`.
+ */
+public class JavacErrorTypeBinding extends JavacTypeBinding {
+
+	private TypeSymbol originatingSymbol;
+
+	public JavacErrorTypeBinding(Type type, final TypeSymbol typeSymbol, boolean isDeclaration,
+			JavacBindingResolver resolver, TypeSymbol originatingSymbol) {
+		super(type, typeSymbol, isDeclaration, resolver);
+		this.originatingSymbol = originatingSymbol;
+	}
+
+	@Override
+	public String getKey() {
+		return getKeyImpl();
+	}
+
+	private String getKeyImpl() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("L");
+		String packageName = "";
+		if (originatingSymbol.packge() != null) {
+			packageName = originatingSymbol.packge().getQualifiedName().toString();
+		}
+		if (!packageName.isEmpty()) {
+			builder.append(packageName.replace(".", "/"));
+			builder.append("/");
+		}
+		String typeName = originatingSymbol.getQualifiedName().toString();
+		if (!packageName.isEmpty()) {
+			typeName = typeName.substring(packageName.length() + 1);
+		}
+		if (typeName.indexOf(".") < 0
+				&& !((ClassSymbol) originatingSymbol).sourcefile.getName().endsWith(typeName + ".java")) {
+			String fileName = ((ClassSymbol) originatingSymbol).sourcefile.toUri().getPath();
+			int lastSlash = fileName.lastIndexOf('/');
+			if (lastSlash >= 0) {
+				fileName = fileName.substring(lastSlash + 1);
+			}
+			int lastDot = fileName.lastIndexOf('.');
+			fileName = fileName.substring(0, lastDot);
+			// file~ prefix is used only for top-level and top-level not matching file name
+			if (!fileName.equals(typeName)) {
+				builder.append(fileName);
+				builder.append('~');
+			}
+		}
+		builder.append(typeName.replace(".", "$"));
+		builder.append(";");
+		return builder.toString();
+	}
+
+}


### PR DESCRIPTION
- precalculate extends or implements info
- When there is no prefix, suggest types declared in the same class, eg. suggest `MyInterface` in the following snippet

```java
public class MyClass implements | {

}

interface MyInterface {}
```

- Better recovery of bindings for classes with incomplete extends or implements sections
  - previously the binding key was always `*`, which caused many that relied on the binding key to break

- Use ExtendsOrImplements info filtering in more places