### PR TITLE
Stabilize testDuplicateLocal

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -52,11 +52,11 @@ import org.eclipse.jdt.core.dom.IPackageBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.JavacBindingResolver;
+import org.eclipse.jdt.core.dom.JavacBindingResolver.BindingKeyException;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.RecordDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
-import org.eclipse.jdt.core.dom.JavacBindingResolver.BindingKeyException;
 import org.eclipse.jdt.internal.compiler.codegen.ConstantPool;
 import org.eclipse.jdt.internal.core.BinaryType;
 import org.eclipse.jdt.internal.core.JavaElement;
@@ -67,12 +67,9 @@ import org.eclipse.jdt.internal.core.SourceType;
 import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Kinds;
-import com.sun.tools.javac.code.Symbol;
-import com.sun.tools.javac.code.Type;
-import com.sun.tools.javac.code.TypeTag;
-import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.code.Kinds.Kind;
 import com.sun.tools.javac.code.Kinds.KindSelector;
+import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.CompletionFailure;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
@@ -81,6 +78,7 @@ import com.sun.tools.javac.code.Symbol.RootPackageSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Symbol.TypeVariableSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.ArrayType;
 import com.sun.tools.javac.code.Type.ClassType;
 import com.sun.tools.javac.code.Type.ErrorType;
@@ -90,6 +88,8 @@ import com.sun.tools.javac.code.Type.JCVoidType;
 import com.sun.tools.javac.code.Type.MethodType;
 import com.sun.tools.javac.code.Type.TypeVar;
 import com.sun.tools.javac.code.Type.WildcardType;
+import com.sun.tools.javac.code.TypeTag;
+import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.code.Types.FunctionDescriptorLookupError;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Names;
@@ -561,7 +561,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 			.filter(VarSymbol.class::isInstance)
 			.map(VarSymbol.class::cast)
 			.filter(sym -> sym.name != this.names.error)
-			.map(this.resolver.bindings::getVariableBinding)
+			.map(varSym -> this.resolver.bindings.getVariableBinding(varSym, true))
 			.filter(Objects::nonNull)
 			.toArray(IVariableBinding[]::new);
 	}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
@@ -59,10 +59,12 @@ public abstract class JavacVariableBinding implements IVariableBinding {
 
 	public final VarSymbol variableSymbol;
 	private final JavacBindingResolver resolver;
+	private final boolean isUnique;
 
-	public JavacVariableBinding(VarSymbol sym, JavacBindingResolver resolver) {
+	public JavacVariableBinding(VarSymbol sym, JavacBindingResolver resolver, boolean isUnique) {
 		this.variableSymbol = sym;
 		this.resolver = resolver;
+		this.isUnique = isUnique;
 	}
 
 	@Override
@@ -194,10 +196,11 @@ public abstract class JavacVariableBinding implements IVariableBinding {
 			return builder.toString();
 		} else if (this.variableSymbol.owner instanceof MethodSymbol methodSymbol) {
 			JavacMethodBinding.getKey(builder, methodSymbol, methodSymbol.type instanceof Type.MethodType methodType ? methodType : null, null, this.resolver);
-			// TODO, need to replace the '0' with an integer representing location in the method. Unclear how to do so.
-			// It needs to trace upwards through the blocks, with a # for each parent block
-			// and a number representing something like what statement in the block it is??
-			builder.append("#"); //0#";
+			// no need to get it right, just get it right enough
+			if (!isUnique) {
+				builder.append(this.variableSymbol.pos);
+			}
+			builder.append("#");
 			builder.append(this.variableSymbol.name);
 			// FIXME: is it possible for the javac AST to contain multiple definitions of the same variable?
 			// If so, we will need to distinguish them (@see org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding)


### PR DESCRIPTION
- Fix the number part of IVariableBinding's key
  - This means that the bindings for different variables with the same name in the same method can be distinguished eg. `rob` and `i` can be distinguished:

```java
public class Main {
	public void myMethod() {
		for (int i = 0; i < 10; i++) {
			int rob = 12;
		}
		for (String i = "asdf"; "hjkl".equals(i); i = "hjkl") {
			String rob = "rob";
		}
	}
}
```

- As a result, completion works deterministically in these cases (eg. before you just had to hope that the correct binding was cached in order to get the right results)