### PR TITLE
Allow using any static fields when initializing field

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
@@ -2877,17 +2877,24 @@ public class DOMCompletionEngine implements ICompletionEngine {
 				} else if (typeDecl instanceof AnonymousClassDeclaration anonymousTypeDeclaration) {
 					bodyDeclarations = anonymousTypeDeclaration.bodyDeclarations();
 				}
-				for (int i = 0; i < indexOfField + 1; i++) {
+				boolean isCursorFieldStatic = Flags.isStatic(fieldDeclaration.getModifiers());
+				for (int i = 0; i < bodyDeclarations.size(); i++) {
 					if (bodyDeclarations.get(i) instanceof FieldDeclaration fieldDecl) {
-						List<VariableDeclarationFragment> frags = fieldDecl.fragments();
-						int fragIterEndpoint = frags.indexOf(fragment);
-						if (fragIterEndpoint == -1) {
-							fragIterEndpoint = frags.size();
-						}
-						for (int j = 0; j < fragIterEndpoint; j++) {
-							IVariableBinding varBinding = frags.get(j).resolveBinding();
-							if (accessFilter.test(varBinding)) {
-								scope.add(varBinding);
+						// static field declarations after the current declaration can be used in completion,
+						// since they will be assigned during object creation
+						if (isCursorFieldStatic
+								? (Flags.isStatic(fieldDecl.getModifiers()) && i < indexOfField + 1)
+								: (Flags.isStatic(fieldDecl.getModifiers()) || i < indexOfField + 1)) {
+							List<VariableDeclarationFragment> frags = fieldDecl.fragments();
+							int fragIterEndpoint = frags.indexOf(fragment);
+							if (fragIterEndpoint == -1) {
+								fragIterEndpoint = frags.size();
+							}
+							for (int j = 0; j < fragIterEndpoint; j++) {
+								IVariableBinding varBinding = frags.get(j).resolveBinding();
+								if (accessFilter.test(varBinding)) {
+									scope.add(varBinding);
+								}
 							}
 						}
 					}


### PR DESCRIPTION
See `CompletionTests.testBug332268a`

eg. should allow completing `val4` in the example below:

```java
public class Main {
  public int val1 = 12;
  public int val2 = 13;
  public int val3 = |;
  public static int val4 = 15;
}
```

Also, handle static completions properly (don't suggest non-static field for completion, only suggest static fields that are initialized before the current one)