### PR TITLE
Suggested name completion

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/SignatureUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/SignatureUtils.java
@@ -121,7 +121,7 @@ public class SignatureUtils {
 	 * @return the signature of the given type key
 	 */
 	public static String getSignatureForTypeKey(String key) {
-		return key.replace('/', '.');
+		return key.replace('/', '.').replaceFirst("(?<=\\.|L)[_$A-Za-z][_$A-Za-z0-9]*~", "");
 	}
 
 	/**

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorTypeBinding.java
@@ -24,9 +24,9 @@ public class JavacErrorTypeBinding extends JavacTypeBinding {
 
 	private TypeSymbol originatingSymbol;
 
-	public JavacErrorTypeBinding(Type type, final TypeSymbol typeSymbol, boolean isDeclaration,
+	public JavacErrorTypeBinding(Type type, final TypeSymbol typeSymbol, Type[] alternatives, boolean isDeclaration,
 			JavacBindingResolver resolver, TypeSymbol originatingSymbol) {
-		super(type, typeSymbol, isDeclaration, resolver);
+		super(type, typeSymbol, alternatives, isDeclaration, resolver);
 		this.originatingSymbol = originatingSymbol;
 	}
 

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeVariableBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeVariableBinding.java
@@ -17,8 +17,8 @@ import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.JavacBindingResolver;
 import org.eclipse.jdt.core.dom.JavacBindingResolver.BindingKeyException;
 
-import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Symbol.TypeVariableSymbol;
+import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.TypeVar;
 
 /**
@@ -31,7 +31,7 @@ public abstract class JavacTypeVariableBinding extends JavacTypeBinding {
 	private final TypeVar typeVar;
 
 	public JavacTypeVariableBinding(TypeVar type, TypeVariableSymbol sym, JavacBindingResolver bindingResolver) {
-		super(type, sym, false, bindingResolver);
+		super(type, sym, null, false, bindingResolver);
 		this.typeVar = type;
 		this.sym = sym;
 		this.bindingResolver = bindingResolver;

--- a/org.eclipse.jdt.core.tests.javac/src/org/eclipse/jdt/core/tests/javac/JavacSpecificCompletionTests.java
+++ b/org.eclipse.jdt.core.tests.javac/src/org/eclipse/jdt/core/tests/javac/JavacSpecificCompletionTests.java
@@ -413,7 +413,7 @@ public class JavacSpecificCompletionTests {
 		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
 		IProgressMonitor monitor = new NullProgressMonitor();
 		this.workingCopies[0].codeComplete(cursorLocation, requestor, WC_OWNER, monitor);
-		assertEquals("myField[FIELD_REF_WITH_CASTED_RECEIVER]{((DemoClass)obj /* obj.nestedField is definitely a DemoClass */ . nestedField) . myField, LDemoClass;, I, LHelloWorld~DemoClass;, myField, replace[152, 223], receiver[152, 219], 60}", requestor.getResults());
+		assertEquals("myField[FIELD_REF_WITH_CASTED_RECEIVER]{((DemoClass)obj /* obj.nestedField is definitely a DemoClass */ . nestedField) . myField, LDemoClass;, I, LDemoClass;, myField, replace[152, 223], receiver[152, 219], 60}", requestor.getResults());
 	}
 
 	@Test


### PR DESCRIPTION
Handle suggested names. eg the following suggests `myObject`:

```java
MyObject |
```

The following suggests `myObjects`:

```java
MyObject[] |
```

I also need to fix union type bindings as a part of this PR in order to properly handle catch statements.

This PR DOESN'T handle variables that are referenced but not declared, eg. `myVar` should be suggested here, but it isn't yet:

```java
int |
myVar = myVar + 12;
```

Fixes #1263