### PR TITLE
Qualified completion in case statements

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionContext.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionContext.java
@@ -410,6 +410,12 @@ class DOMCompletionContext extends CompletionContext {
 						|| sig2.equals(Signature.SIG_INT)
 						|| sig2.equals(Signature.SIG_DOUBLE)
 						|| sig2.equals(Signature.SIG_FLOAT);
+			case Signature.SIG_SHORT:
+				return sig2.equals(Signature.SIG_LONG)
+						|| sig2.equals(Signature.SIG_INT)
+						|| sig2.equals(Signature.SIG_SHORT)
+						|| sig2.equals(Signature.SIG_DOUBLE)
+						|| sig2.equals(Signature.SIG_FLOAT);
 			case Signature.SIG_BYTE:
 				return sig2.equals(Signature.SIG_LONG)
 						|| sig2.equals(Signature.SIG_INT)

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/SignatureUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/SignatureUtils.java
@@ -152,4 +152,19 @@ public class SignatureUtils {
 			return removeName;
 		}
 	}
+
+	/**
+	 * Returns true if the given signature is a primitive number, and false
+	 * otherwise.
+	 *
+	 * @param sig the signature to check
+	 * @return true if the given signature is a primitive number, and false
+	 *         otherwise
+	 */
+	public static boolean isNumeric(String sig) {
+		return sig.equals(Signature.SIG_BYTE) || sig.equals(Signature.SIG_CHAR) || sig.equals(Signature.SIG_DOUBLE)
+				|| sig.equals(Signature.SIG_FLOAT) || sig.equals(Signature.SIG_INT) || sig.equals(Signature.SIG_LONG)
+				|| sig.equals(Signature.SIG_SHORT);
+	}
+
 }


### PR DESCRIPTION
eg. completion at `|` should suggest `VALUEABLE_1` and properly filter out eg. methods and non-static/final fields.

```java
public class DemoClass {
	void thisMethod() {
		int i = 12;
		switch (i) {
			case MyInner.|
		}
	}
	public static class MyInner {
		final static int VALUEABLE_1 = 1;
	}
}
```

Fixes 1 case, improves a few others so that only the relevance numbers are wrong.