### PR TITLE
Prevent CompletionFailure from bubbling up (and freezing IDE)

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
@@ -720,7 +720,12 @@ public class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 			var aptPath = fileManager.getLocation(StandardLocation.ANNOTATION_PROCESSOR_PATH);
 			if ((flags & ICompilationUnit.FORCE_PROBLEM_DETECTION) != 0
 				|| (aptPath != null && aptPath.iterator().hasNext())) {
-				task.analyze();
+				try {
+					task.analyze();
+				} catch (Throwable t) {
+					ILog.get().error("Error while analyzing", t);
+					// continue anyway
+				}
 			}
 
 			Throwable cachedThrown = null;


### PR DESCRIPTION
Reconciling or other routines may receive a CompletionFailure in some -more or less valid- cases. Instead of letting the exception bubble up to user land, we simply log it and continue anyway.