### PR TITLE
Another round of keyword completions

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -1594,16 +1594,19 @@ public class JavacBindingResolver extends BindingResolver {
 			if (importDeclaration.isStatic()) {
 				com.sun.tools.javac.code.Type type = fieldAccess.getExpression().type;
 				if (type != null) {
-					IBinding binding = Arrays.stream(this.bindings.getTypeBinding(type).getDeclaredMethods())
-						.filter(method -> Objects.equals(fieldAccess.getIdentifier().toString(), method.getName()))
-						.findAny()
-						.orElse(null);
-					if (binding == null) {
-						binding = Arrays.stream(this.bindings.getTypeBinding(type).getDeclaredFields()).filter(
-								field -> Objects.equals(fieldAccess.getIdentifier().toString(), field.getName()))
-								.findAny().orElse(null);
+					ITypeBinding typeBinding = this.bindings.getTypeBinding(type);
+					if (typeBinding != null) {
+						IBinding binding = Arrays.stream(typeBinding.getDeclaredMethods())
+								.filter(method -> Objects.equals(fieldAccess.getIdentifier().toString(), method.getName()))
+								.findAny()
+								.orElse(null);
+						if (binding == null) {
+							binding = Arrays.stream(typeBinding.getDeclaredFields()).filter(
+									field -> Objects.equals(fieldAccess.getIdentifier().toString(), field.getName()))
+									.findAny().orElse(null);
+						}
+						return binding;
 					}
-					return binding;
 				}
 			}
 		}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -407,6 +407,9 @@ class JavacConverter {
 		} else {
 			res.setName(toName(select));
 		}
+		if (res.getName().toString().contains(JavacConverter.FAKE_IDENTIFIER)) {
+			res.setFlags(res.getFlags() | ASTNode.MALFORMED);
+		}
 		if (javac.isStatic() || javac.isModule()) {
 			if (this.ast.apiLevel < AST.JLS23_INTERNAL) {
 				if (!javac.isStatic()) {


### PR DESCRIPTION
- Completion for `instanceof` keyword
  - Since it's sort of like an infix operator, I needed to write some more involved logic to get it to work properly.
- Suggest all type-declaration like keywords instead of just `class`
  - eg. `enum`, `interface`, `record`
- Complete the `import` keyword
  - See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3799, I won't fix that test case
- fix module import completion (only show it when `import module` is used)
- fix replace range on package completion
  - It uses the nested engine currently and the root cause was us not modifying the internal state correctly. I think using nested engine is bad, but I did the lazy hack instead of replacing the nested engine with our own `ISearchRequestor` implementation