### PR TITLE
Improve "override method" completion

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/KeyUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/KeyUtils.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.codeassist;
+
+/**
+ * Utility methods for manipulating binding keys.
+ */
+public class KeyUtils {
+
+	/**
+	 * Returns the given method key with the owner type and return type removed.
+	 * 
+	 * @param methodKey the method key to remove the owner type and return type from
+	 * @return the given method key with the owner type and return type removed
+	 */
+	public static final String getMethodKeyWithOwnerTypeAndReturnTypeRemoved(String methodKey) {
+		return methodKey.substring(methodKey.indexOf('.'), methodKey.lastIndexOf(')') + 1);
+	}
+
+}


### PR DESCRIPTION
- Handle qualifying types referenced in the method declaration
  - eg. do not qualify imported types
  - eg. do not qualify types from the same package
  - eg. do not qualify inner classes nor inherited inner classes
- Fix parameter names
  - get them from the `IMethod`, which has more accurate
- Handle completion in anonymous classes
- Do not suggest overriding a method that's already overriden