### PR TITLE
Primitive types can autobox to `java.lang.Object`

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/RelevanceUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/RelevanceUtils.java
@@ -131,6 +131,10 @@ class RelevanceUtils {
 						relevance = CompletionEngine.R_EXPECTED_TYPE;
 					}
 				}
+				if ("Ljava/lang/Object;".equals(expectedType.getKey()) && proposalType.isPrimitive()) {
+					// can be autoboxed
+					relevance = CompletionEngine.R_EXPECTED_TYPE;
+				}
 			}
 			return relevance;
 		}


### PR DESCRIPTION
(for expected types purposes)