### PR TITLE
Many NPE fixes in completion

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
@@ -194,6 +194,16 @@ public class ExpectedTypes {
 				}
 				break;
 			}
+			if (parent2 instanceof ParameterizedType parameterizedType) {
+				ITypeBinding typeBinding = parameterizedType.getType().resolveBinding().getTypeDeclaration();
+				// TODO: does this ever happen for other entries?
+				if (typeBinding.getTypeParameters()[0].isWildcardType() && typeBinding.getTypeParameters()[0].getBound() != null) {
+					this.expectedTypes.add(typeBinding.getTypeParameters()[0].getBound());
+				} else {
+					this.expectedTypes.add(parent2.getAST().resolveWellKnownType(Object.class.getName()));
+				}
+				return;
+			}
 			if (parent2.getLocationInParent() == MemberValuePair.VALUE_PROPERTY && parent2.getParent() instanceof MemberValuePair mvp) {
 				var binding = mvp.resolveMemberValuePairBinding();
 				if (binding != null) {

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/KeyUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/KeyUtils.java
@@ -17,6 +17,8 @@ package org.eclipse.jdt.internal.codeassist;
  * Utility methods for manipulating binding keys.
  */
 public class KeyUtils {
+	
+	public static final String OBJECT_KEY = "Ljava/lang/Object;";
 
 	/**
 	 * Returns the given method key with the owner type and return type removed.

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/RelevanceUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/RelevanceUtils.java
@@ -131,7 +131,7 @@ class RelevanceUtils {
 						relevance = CompletionEngine.R_EXPECTED_TYPE;
 					}
 				}
-				if ("Ljava/lang/Object;".equals(expectedType.getKey()) && proposalType.isPrimitive()) {
+				if (KeyUtils.OBJECT_KEY.equals(expectedType.getKey()) && proposalType.isPrimitive()) {
 					// can be autoboxed
 					relevance = CompletionEngine.R_EXPECTED_TYPE;
 				}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -58,6 +58,7 @@ import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.RecordDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.internal.codeassist.KeyUtils;
 import org.eclipse.jdt.internal.compiler.codegen.ConstantPool;
 import org.eclipse.jdt.internal.core.BinaryType;
 import org.eclipse.jdt.internal.core.JavaElement;
@@ -314,10 +315,10 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 	}
 	
 	private String computeKey() {
-		return getKeyWithPossibleGenerics(this.type, this.typeSymbol, ITypeBinding::getKey, true);
+		return getKeyWithPossibleGenerics(this.type, this.typeSymbol, tb -> tb != null ? tb.getKey() : KeyUtils.OBJECT_KEY, true);
 	}
 	public String getKeyWithPossibleGenerics(Type t, TypeSymbol s) {
-		return getKeyWithPossibleGenerics(t, s, ITypeBinding::getKey);
+		return getKeyWithPossibleGenerics(t, s, tb -> tb != null ? tb.getKey() : KeyUtils.OBJECT_KEY);
 	}
 	private String getKeyWithPossibleGenerics(Type t, TypeSymbol s, Function<ITypeBinding, String> parameterizedCallback) {
 		return getKeyWithPossibleGenerics(t, s, parameterizedCallback, false);
@@ -373,7 +374,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 			return '[' + componentBinding.getGenericTypeSignature(useSlashes);
 		}
 		String ret = getKeyWithPossibleGenerics(t, s, 
-				x -> x instanceof JavacTypeBinding jtb ? jtb.getGenericTypeSignature(useSlashes) : x.getKey(),
+				x -> x instanceof JavacTypeBinding jtb ? jtb.getGenericTypeSignature(useSlashes) : x != null ? x.getKey() : KeyUtils.OBJECT_KEY,
 						useSlashes);
 		return ret;
 	}


### PR DESCRIPTION
- Prevent NPE when completing name of the last parameter in a method declaration
  - This uses the existing "suggest a name for this variable" logic
- Prevent various NPEs when completing the first parameter of a parameterized type
  - eg.
    ```java
    List<| asdf = new ArrayList<>();
    ```
- move private check before deprecated check to avoid NPE trying to
  access the `IMethod` for a private JDK class member.
  (I think the root cause is that the private method doesn't exist in the
  stubbed jar, so we can't access the associated `IMethod`, but it does
  exist in javac's internal bindings, since javac has access to the real
  JDK class)
- when completing throws clause, add null checks when accessing the
  return type and name to compute the scanning index
  - constructors don't have a return type node, and an incomplete method
    declaration might not have a name
- replace a use of "Ljava/lang/Object;" with the constant from KeyUtils

Should fix 5 cases, and switch several test errors over to failures.