### PR TITLE
More error/NPE fixes in completion

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngineBuilder.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngineBuilder.java
@@ -73,7 +73,11 @@ class DOMCompletionEngineBuilder {
 		ITypeBinding[] parameterTypes = methodBinding.getParameterTypes();
 		String[] parameterNames;
 		try {
-			parameterNames = ((IMethod)methodBinding.getJavaElement()).getParameterNames();
+			if (methodBinding.getJavaElement() != null) {
+				parameterNames = ((IMethod)methodBinding.getJavaElement()).getParameterNames();
+			} else {
+				parameterNames = methodBinding.getParameterNames();
+			}
 		} catch (JavaModelException e) {
 			parameterNames = methodBinding.getParameterNames();
 		}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/SignatureUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/SignatureUtils.java
@@ -123,7 +123,7 @@ public class SignatureUtils {
 	public static String getSignatureForTypeKey(String key) {
 		return key.replace('/', '.').replaceFirst("(?<=\\.|L)[_$A-Za-z][_$A-Za-z0-9]*~", "");
 	}
-
+	
 	/**
 	 * Returns the signature of the given method binding as a character array.
 	 *
@@ -131,7 +131,7 @@ public class SignatureUtils {
 	 * @return the signature of the given method binding as a character array
 	 */
 	public static char[] getSignatureChar(IMethodBinding methodBinding) {
-		return SignatureUtils.getSignatureForMethodKey(methodBinding.getKey()).toCharArray();
+		return getSignatureForMethodKey(methodBinding.getKey()).toCharArray();
 	}
 
 	/**


### PR DESCRIPTION
- handle completing package-qualified method parameter type
- do not suggest overriding existing or declaring new methods  annotation type declarations
- when building override method completions, if the `IMethod` of a given method binding cannot be found, use the parameter names from the bindings instead
- prevent NPE when attempting to suggest completion for a method with an incomplete parameter type