### PR TITLE
Skip running jdt.core tests without javac

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,54 +13,6 @@ pipeline {
 		jdk 'openjdk-jdk24-latest'
 	}
 	stages {
-		stage('Build and Test') {
-			steps {
-					sh """#!/bin/bash -x
-					
-					java -version
-					
-					mkdir -p $WORKSPACE/tmp
-					
-					unset JAVA_TOOL_OPTIONS
-					unset _JAVA_OPTIONS
-					
-					# The max heap should be specified for tycho explicitly
-					# via configuration/argLine property in pom.xml
-					# export MAVEN_OPTS="-Xmx2G"
-					
-					mvn clean install -f org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99 -Dmaven.repo.local=$WORKSPACE/.m2/repository -DcompilerBaselineMode=disable -DcompilerBaselineReplace=none
-
-					# Build and test without DOM-first to ensure no regression takes place
-					mvn -U clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-						-pl !org.eclipse.jdt.core.tests.javac \
-						-Ptest-on-javase-24 -Pbree-libs -Papi-check -Pjavadoc -Pp2-repo \
-						-Dmaven.test.failure.ignore=true \
-						-Dcompare-version-with-baselines.skip=false \
-						-Djava.io.tmpdir=$WORKSPACE/tmp -Dproject.build.sourceEncoding=UTF-8 \
-						-Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17,21,23,24 -Djdt.performance.asserts=disabled" \
-						-DDetectVMInstallationsJob.disabled=true \
-						-Dtycho.apitools.debug \
-						-Dtycho.debug.artifactcomparator \
-						-e \
-						-Dcbi-ecj-version=99.99
-					"""
-			}
-			post {
-				always {
-					// The following lines use the newest build on master that did not fail a reference
-					// To not fail master build on failed test maven needs to be started with "-Dmaven.test.failure.ignore=true" it will then only marked unstable.
-					// To not fail the build also "unstable: true" is used to only mark the build unstable instead of failing when qualityGates are missed
-					// Also do not record mavenConsole() as failing tests are logged with ERROR duplicating the failure into the "Maven" plugin
-					// To accept unstable builds (test errors or new warnings introduced by third party changes) as reference using "ignoreQualityGate:true"
-					// To only show warnings related to the PR on a PR using "publishAllIssues:false"
-					// The eclipse compiler name is changed because the logfile not only contains ECJ but also API warnings.
-					// "pattern:" is used to collect warnings in dedicated files avoiding output of junit tests treated as warnings   
-					junit '**/target/surefire-reports/*.xml'
-					//discoverGitReferenceBuild referenceJob: 'eclipse.jdt.core-github/master'
-					//recordIssues publishAllIssues:false, ignoreQualityGate:true, tool: eclipse(name: 'Compiler and API Tools', pattern: '**/target/compilelogs/*.xml'), qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]]
-				}
-			}
-		}
 		stage('javac specific tests') {
 			steps {
 				sh """#!/bin/bash -x
@@ -74,8 +26,7 @@ pipeline {
 						-Dtycho.buildqualifier.format="'z'yyyyMMdd-HHmm" \
 						-Pp2-repo \
 						-Djava.io.tmpdir=$WORKSPACE/tmp -Dproject.build.sourceEncoding=UTF-8 \
-						-Dcbi-ecj-version=99.99 \
-						-pl org.eclipse.jdt.core.compiler.batch,org.eclipse.jdt.core,org.eclipse.jdt.core.javac,org.eclipse.jdt.core.javac.feature,org.eclipse.jdt.core.tests.model,org.eclipse.jdt.core.tests.compiler,repository
+						-pl org.eclipse.jdt.core.javac,org.eclipse.jdt.core.javac.feature,org.eclipse.jdt.core.tests.model,org.eclipse.jdt.core.tests.compiler,repository
 
 					mvn verify --batch-mode -f org.eclipse.jdt.core.tests.javac -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						--fail-at-end -Ptest-on-javase-24 -Pbree-libs \


### PR DESCRIPTION
- This will save 40-50 minutes in each Jenkins build
- We don't have substantial changes in jdt.core anymore. As such, we don't really need to test these changes.

Currently, there are ~~11~~ 3 files that are changed:

~~PatternLocator.java~~
~~MatchingNodeSet.java (just whitespace changes)~~
~~MatchLocator.java~~
~~SourceIndexer.java (see https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3846)~~
~~DOMToIndexVisitor.java (see https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3846)~~
~~IJavaSearchDelegate.java (`@since` changes only)~~
~~DOMToModelPopulator.java (see https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3846)~~
~~org.eclipse.jdt.internal.core.CompilationUnit (formatting changes only) JavaCore.java (`@since` changes only)~~
~~AST.java (`@since` changes only)~~
~~CompletionEngine.java (make a few methods static)~~

As noted, only ~6~ ~3~ 0 of these files have "real" changes, and of those, most of them are classes that we introduced upstream that are only used when running with javac.