### PR TITLE
Completion Perf: Delay `scrapeAccessibleBindings`

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -1001,6 +1001,7 @@ public class JavacBindingResolver extends BindingResolver {
 	}
 
 	IBinding resolveCached(ASTNode node, Function<ASTNode, IBinding> l) {
+		resolve();
 		// Avoid using `computeIfAbsent` because it throws
 		// ConcurrentModificationException when nesting calls
 		var res = resolvedBindingsCache.get(node);


### PR DESCRIPTION
scrapeAccessibleBindings may run some search and queries that can be time consuming (~10% of completion time), however, the results of those queries are not always useful.
So instead of forcing the computation of binding early, we allow to mark them as "requested" so that they would be computed lazily, typically when applying a method completion proposal.