### PR TITLE
Treat method parameter types as possibly generic

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMTypeParameterLocator.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMTypeParameterLocator.java
@@ -99,10 +99,11 @@ public class DOMTypeParameterLocator extends DOMPatternLocator {
 			if (this.locator.matchesName(methBinding.getDeclaringClass().getName().toCharArray(), this.locator.pattern.methodDeclaringClassName) &&
 				(methBinding.isConstructor() || this.locator.matchesName(methBinding.getName().toCharArray(), this.locator.pattern.declaringMemberName))) {
 				int length = this.locator.pattern.methodArgumentTypes==null ? 0 : this.locator.pattern.methodArgumentTypes.length;
-				if (methBinding.getParameterTypes() == null) {
+				ITypeBinding[] pTypes = methBinding.getParameterTypes();
+				if (pTypes == null) {
 					if (length == 0) return ACCURATE_MATCH;
-				} else if (methBinding.getParameterTypes().length == length){
-					ITypeBinding[] p = methBinding.getParameterTypes();
+				} else if (pTypes.length == length){
+					ITypeBinding[] p = pTypes;
 					for (int i=0; i<length; i++) {
 						if (!this.locator.matchesName(this.locator.pattern.methodArgumentTypes[i], p[i].getName().toCharArray())) {
 							return IMPOSSIBLE_MATCH;

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
@@ -31,11 +31,11 @@ import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.JavacBindingResolver;
+import org.eclipse.jdt.core.dom.JavacBindingResolver.BindingKeyException;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.TypeParameter;
-import org.eclipse.jdt.core.dom.JavacBindingResolver.BindingKeyException;
 import org.eclipse.jdt.internal.core.BinaryMethod;
 import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.Member;
@@ -47,11 +47,11 @@ import org.eclipse.jdt.internal.core.util.Util;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Kinds;
 import com.sun.tools.javac.code.Symbol;
-import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.ForAll;
 import com.sun.tools.javac.code.Type.JCNoType;
 import com.sun.tools.javac.code.Type.MethodType;
@@ -97,7 +97,7 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 
 	private static boolean isParameterized(Symbol symbol) {
 		while (symbol != null) {
-			if (symbol.type != null && 
+			if (symbol.type != null &&
 				(symbol.type.isParameterized() || symbol.type instanceof ForAll)) {
 				return true;
 			}
@@ -203,14 +203,14 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 		this.javaElement = resolved(getUnresolvedJavaElement());
 		return this.javaElement;
 	}
-	
+
 	IMethod getUnresolvedJavaElement() {
 		if (this.javaElement == null) {
 			this.javaElement = computeUnresolvedJavaElement();
 		}
 		return this.javaElement;
 	}
-	
+
 	private IMethod computeUnresolvedJavaElement() {
 		if (this.methodSymbol == null) {
 			return null;
@@ -224,7 +224,7 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 				} else if (declaringNode instanceof AnnotationTypeMemberDeclaration annotationTypeMemberDeclaration) {
 					return getJavaElementForAnnotationTypeMemberDeclaration(currentType, annotationTypeMemberDeclaration);
 				}
-	
+
 				var parametersResolved = this.methodSymbol.params().stream()
 						.map(varSymbol -> varSymbol.type)
 						.map(t ->
@@ -361,7 +361,7 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 		}
 		return this.key;
 	}
-	
+
 	private String computeKey() {
 		try {
 			StringBuilder builder = new StringBuilder();
@@ -375,7 +375,7 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 	static void getKey(StringBuilder builder, MethodSymbol methodSymbol, MethodType methodType, Type parentType, JavacBindingResolver resolver) throws BindingKeyException {
 		getKey(builder, methodSymbol, methodType, parentType, false, resolver);
 	}
-	
+
 	static void getKey(StringBuilder builder, MethodSymbol methodSymbol, MethodType methodType, Type parentType, boolean useSlashes, JavacBindingResolver resolver) throws BindingKeyException {
 
 		if (parentType != null) {
@@ -514,7 +514,7 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 		ITypeBinding[] res = new ITypeBinding[this.methodType.getParameterTypes().length()];
 		for (int i = 0; i < res.length; i++) {
 			Type paramType = methodType.getParameterTypes().get(i);
-			ITypeBinding paramBinding = this.resolver.bindings.getTypeBinding(paramType);
+			ITypeBinding paramBinding = this.resolver.bindings.getTypeBinding(paramType, true);
 			if (paramBinding == null) {
 				// workaround javac missing recovery symbols for unresolved parameterized types
 				if (this.resolver.findDeclaringNode(this) instanceof MethodDeclaration methodDecl) {
@@ -571,23 +571,23 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 		}
 		return false;
 	}
-	
+
 	private boolean methodHasGenerics() {
 		boolean b1 = (isConstructor() && getDeclaringClass().isGenericType())
 				|| (!this.methodSymbol.getTypeParameters().isEmpty() && isDeclaration);
 		return b1;
 	}
-	
+
 	@Override
 	public boolean isParameterizedMethod() {
 		return !isRawMethod() && !methodHasGenerics() && methodMatchesParameterized();
 	}
-	
+
 	private boolean methodMatchesParameterized() {
-		return ((isConstructor() && getDeclaringClass().isParameterizedType()) 
+		return ((isConstructor() && getDeclaringClass().isParameterizedType())
 				|| (!this.methodSymbol.getTypeParameters().isEmpty() && !isDeclaration));
 	}
-	
+
 	@Override
 	public boolean isRawMethod() {
 		if (isConstructor()) {

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -113,13 +113,13 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 	private IJavaElement javaElement;
 	private String key;
 
-	public JavacTypeBinding(Type type, final TypeSymbol typeSymbol, Type[] alternatives, boolean isDeclaration, JavacBindingResolver resolver) {
+	public JavacTypeBinding(Type type, final TypeSymbol typeSymbol, Type[] alternatives, boolean possiblyGeneric, JavacBindingResolver resolver) {
 		if (!JavacBindingResolver.isTypeOfType(type)) {
 			if (typeSymbol != null) {
 				type = typeSymbol.type;
 			}
 		}
-		this.isGeneric = type.isParameterized() && isDeclaration;
+		this.isGeneric = type.isParameterized() && possiblyGeneric;
 		this.typeSymbol = (typeSymbol == null || typeSymbol.kind == Kind.ERR) && type != null? type.tsym : typeSymbol;
 		this.type = this.isGeneric || type == null ? this.typeSymbol.type /*generic*/ : type /*specific instance*/;
 		this.resolver = resolver;

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -154,7 +154,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 					.map(am -> this.resolver.bindings.getAnnotationBinding(am, this))
 					.toArray(IAnnotationBinding[]::new);
 		}
-		
+
 	}
 
 	@Override
@@ -193,8 +193,8 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 			this.javaElement = computeJavaElement();
 		}
 		return this.javaElement;
-	}	
-	
+	}
+
 	private IJavaElement computeJavaElement() {
 		if (isTypeVariable() && this.typeSymbol != null) {
 			if (this.typeSymbol.owner instanceof ClassSymbol ownerSymbol
@@ -205,12 +205,12 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 				}
 			} else if (this.typeSymbol.owner instanceof MethodSymbol ownerSymbol
 					&& ownerSymbol.type != null ) {
-				JavacMethodBinding mb = this.resolver.bindings.getMethodBinding(ownerSymbol.type.asMethodType(), ownerSymbol, null, isGeneric); 
+				JavacMethodBinding mb = this.resolver.bindings.getMethodBinding(ownerSymbol.type.asMethodType(), ownerSymbol, null, isGeneric);
 				if( mb.getJavaElement() instanceof IMethod ownerMethod
 						&& ownerMethod.getTypeParameter(this.getName()) != null) {
 					return ownerMethod.getTypeParameter(this.getName());
 				}
-			}	
+			}
 		}
 		if (this.resolver.javaProject == null) {
 			return null;
@@ -235,7 +235,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 					return resolved(method.getType(this.typeSymbol.name.toString(), 1));
 				}
 			}
-			
+
 			JavaFileObject jfo = classSymbol == null ? null : classSymbol.sourcefile;
 			ITypeRoot typeRoot = null;
 			if (jfo != null) {
@@ -315,7 +315,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 		}
 		return this.key;
 	}
-	
+
 	private String computeKey() {
 		return getKeyWithPossibleGenerics(this.type, this.typeSymbol, tb -> tb != null ? tb.getKey() : KeyUtils.OBJECT_KEY, true);
 	}
@@ -350,13 +350,13 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 		}
 		return base1;
 	}
-	
+
 	public String getGenericTypeSignature(boolean useSlashes) {
 		return getGenericTypeSignature(this.type, this.typeSymbol, useSlashes);
 	}
 	public String getGenericTypeSignature(Type t, TypeSymbol s, boolean useSlashes) {
 		if( t instanceof ClassType ct && !s.isAnonymous() && ct.getEnclosingType() != null ) {
-			// return 			Lg1/t/s/def/Generic<Ljava/lang/Exception;>.Member;  
+			// return 			Lg1/t/s/def/Generic<Ljava/lang/Exception;>.Member;
 			// Don't return 	Lg1/t/s/def/Generic$Member<>;
 			Type enclosing = ct.getEnclosingType();
 			if( enclosing != null && enclosing != Type.noType) {
@@ -381,7 +381,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 			JavacTypeBinding componentBinding = this.resolver.bindings.getTypeBinding(component);
 			return '[' + componentBinding.getGenericTypeSignature(useSlashes);
 		}
-		String ret = getKeyWithPossibleGenerics(t, s, 
+		String ret = getKeyWithPossibleGenerics(t, s,
 				x -> x instanceof JavacTypeBinding jtb ? jtb.getGenericTypeSignature(useSlashes) : x != null ? x.getKey() : KeyUtils.OBJECT_KEY,
 						useSlashes);
 		return ret;
@@ -399,7 +399,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 		}
 		return typeKey;
 	}
-	
+
 	private static String removeTrailingSemicolon(String key) {
 		return key.endsWith(";") ? key.substring(0, key.length() - 1) : key;
 	}
@@ -436,7 +436,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 	static void getKey(StringBuilder builder, Type typeToBuild, boolean isLeaf, JavacBindingResolver resolver) throws BindingKeyException {
 		getKey(builder, typeToBuild, typeToBuild.asElement().flatName(), isLeaf, false, false, resolver);
 	}
-	
+
 	static void getKey(StringBuilder builder, Type typeToBuild, boolean isLeaf, boolean includeParameters, JavacBindingResolver resolver) throws BindingKeyException {
 		getKey(builder, typeToBuild, typeToBuild.asElement().flatName(), isLeaf, includeParameters, false, resolver);
 	}
@@ -448,7 +448,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 	static void getKey(StringBuilder builder, Type typeToBuild, Name n, boolean isLeaf, boolean includeParameters, JavacBindingResolver resolver) throws BindingKeyException {
 		getKey(builder, typeToBuild, n.toString(), isLeaf, includeParameters, false, resolver);
 	}
-	
+
 	static void getKey(StringBuilder builder, Type typeToBuild, Name n, boolean isLeaf, boolean includeParameters, boolean useSlashes, JavacBindingResolver resolver) throws BindingKeyException {
 		getKey(builder, typeToBuild, n.toString(), isLeaf, includeParameters, useSlashes, resolver);
 	}
@@ -625,12 +625,12 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 				protected void append(char ch) {
 					res.append(ch);
 				}
-	
+
 				@Override
 				protected void append(byte[] ba) {
 					res.append(new String(ba));
 				}
-	
+
 				@Override
 				protected void append(Name name) {
 					res.append(name.toString());
@@ -719,7 +719,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 				return ret;
 			}
 		}
-		
+
 		Stream<JavacMethodBinding> methods = StreamSupport.stream(this.typeSymbol.members().getSymbols(MethodSymbol.class::isInstance, LookupKind.NON_RECURSIVE).spliterator(), false)
 				.map(MethodSymbol.class::cast)
 				.map(sym -> {
@@ -743,7 +743,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 			// recompute it relying on JDT model (which honors the order)
 			methods = methods.sorted(Comparator.comparingInt(binding -> {
 					var elt = binding.getUnresolvedJavaElement(); // unresolved is necessary, as resolved is too expensive
-					return elt != null ? orderedListFromModel.indexOf(elt) : -1; 
+					return elt != null ? orderedListFromModel.indexOf(elt) : -1;
 				}));
 		}
 		return methods.toArray(IMethodBinding[]::new);
@@ -939,7 +939,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 	public String getName() {
 		return getName(true);
 	}
-	
+
 	public String getName(boolean checkParameterized) {
 		if (this.isIntersectionType()) {
 			if (this.alternatives != null) {
@@ -969,7 +969,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 			return builder.toString();
 		}
 		StringBuilder builder = new StringBuilder(this.typeSymbol.getSimpleName().toString());
-		if(checkParameterized && isParameterizedType()) {
+		if(checkParameterized && this.type.isParameterized()) {
 			ITypeBinding[] types = this.getUncheckedTypeArguments(this.type, this.typeSymbol);
 			if (types != null && types.length > 0) {
 				builder.append("<");
@@ -1005,7 +1005,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 	public String getQualifiedName(boolean includeParams) {
 		return getQualifiedNameImpl(this.type, this.typeSymbol, this.typeSymbol.owner, includeParams);
 	}
-	
+
 	protected String getQualifiedNameImpl(Type type, TypeSymbol typeSymbol, Symbol owner, boolean includeParameters) {
 		if (owner instanceof MethodSymbol) {
 			return "";
@@ -1301,7 +1301,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 		return !isRawType(t) && t.isParameterized() && this.isGeneric;
 	}
 
-	
+
 	@Override
 	public boolean isInterface() {
 		return this.typeSymbol.isInterface();


### PR DESCRIPTION
This is a test PR. 

Currently, when a method binding gets asked for the types of its parameters, it gives back type bindings that claim to have no type arguments, because it does not realize it may be generic. 

This is a simple PR to test what regresses by changing this line of code. 