### PR TITLE
Don't try to read symbol for JavacErrorMethodBinding.isVarargs

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacErrorMethodBinding.java
@@ -101,4 +101,9 @@ public abstract class JavacErrorMethodBinding extends JavacMethodBinding {
 		return this.originatingSymbol.getAnnotationMirrors().stream().map(ann -> this.resolver.bindings.getAnnotationBinding(ann, this)).toArray(IAnnotationBinding[]::new);
 	}
 
+	@Override
+	public boolean isVarargs() {
+		return false;
+	}
+
 }


### PR DESCRIPTION
Hardcode value to false to prevent from trying to read the (non-existing) MethodSymbol