### PR TITLE
Make ASTConverterMarkdownText more tolerant

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -675,6 +675,10 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 		Iterator elements = tagElement.fragments().listIterator();
 		while (elements.hasNext()) {
 			ASTNode fragment = (ASTNode) elements.next();
+			// skip whitespace characters that are not included in fragment
+			while (Character.isWhitespace(source[tagStart]) && tagStart < fragment.getStartPosition()) {
+				tagStart++;
+			}
 			if (fragment.getNodeType() == ASTNode.TEXT_ELEMENT) {
 				if (previousFragment == null && TagElement.TAG_PARAM.equals(tagName) && ((TextElement)fragment).getText().equals("<")) { // special case here for @param <E> syntax
 					int start = tagStart;


### PR DESCRIPTION
A parser may decide to keep a TextElement as " blah" with (offset, length)=(N,5); or as "blah" with (offset,length)=(N+1,4). Both are valid.
Make test tolerate both.