### PR TITLE
Search skips visiting EnumConstantDeclaration name

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/PatternLocatorVisitor.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/PatternLocatorVisitor.java
@@ -262,6 +262,7 @@ class PatternLocatorVisitor extends ASTVisitor {
 			loc == SingleVariableDeclaration.NAME_PROPERTY ||
 			loc == TypeDeclaration.NAME_PROPERTY ||
 			loc == EnumDeclaration.NAME_PROPERTY ||
+			loc == EnumConstantDeclaration.NAME_PROPERTY ||
 			loc == MethodDeclaration.NAME_PROPERTY) {
 			return false; // skip as parent was most likely already matched
 		}


### PR DESCRIPTION
The parent EnumConstantDeclaration is already checked, no need to re-check the name.