### PR TITLE
Do not filter out types from file when completing field type

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
@@ -927,7 +927,8 @@ public class DOMCompletionEngine implements ICompletionEngine {
 								} catch (JavaModelException e) {
 									return true;
 								}
-							}).filter(typeMatch -> defaultCompletionBindings.all().map(typeBinding -> typeBinding.getJavaElement()).noneMatch(elt -> typeMatch.getType().equals(elt)))
+							})
+							// no need to filter out defaults, since we aren't performing default completion
 							.filter(typeMatch -> this.pattern.matchesName(this.prefix.toCharArray(), typeMatch.getType().getElementName().toCharArray()))
 							.filter(typeMatch -> filterBasedOnExtendsOrImplementsInfo(typeMatch.getType(), this.extendsOrImplementsInfo))
 							.map(this::toProposal)


### PR DESCRIPTION
eg.

```java
public class MyLinkedList {

  public MyLinkedList(MyLinkedList next) {
    // ... assign next to a field
  }

  MyLink|
}
```

We were filtering `MyLinkedList` out because it was in "default" completion, but we were disabling default completion in this case.