### PR TITLE
[Search] Fix qualifiedSourceName

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMPatternLocator.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMPatternLocator.java
@@ -133,19 +133,13 @@ public class DOMPatternLocator extends PatternLocator {
 		}
 		ITypeBinding type = binding.isArray() ? binding.getComponentType() : binding;
 		String simpleName = type instanceof JavacTypeBinding ? ((JavacTypeBinding)type).getName(false) : binding.getName();
-		String qualifier = qualifiedSourceName(type.getDeclaringClass());
-		if( qualifier == null && type instanceof JavacTypeBinding jctb) {
-			String qualifiedName = jctb.getQualifiedName(false);
-			if( qualifiedName != null ) {
-				return qualifiedName;
-			}
-		}
 		if (type.isLocal()) {
-			return qualifier + ".1." + simpleName; //$NON-NLS-1$
+			return qualifiedSourceName(type.getDeclaringClass()) + ".1." + simpleName; //$NON-NLS-1$
 		} else if (type.isMember()) {
-			return qualifier + '.' + simpleName;
+			return qualifiedSourceName(type.getDeclaringClass()) + '.' + simpleName;
+		} else {
+			return simpleName;
 		}
-		return binding.getName();
 	}
 	protected int resolveLevelForType(char[] simpleNamePattern, char[] qualificationPattern, ITypeBinding binding) {
 		return resolveLevelForTypeFQN(simpleNamePattern, qualificationPattern, binding, null);


### PR DESCRIPTION
qualifiedSourceName is the qualified name (including parent types for nested/local types) but without including the package.

Fixes https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator/issues/1430