### PR TITLE
Fix some constructor completion tests

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/SignatureUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/SignatureUtils.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
@@ -158,6 +159,10 @@ public class SignatureUtils {
 		return key.replace('/', '.').replaceFirst("(?<=\\.|L)[_$A-Za-z][_$A-Za-z0-9]*~", "");
 	}
 
+	public static String getSignature(IMethodBinding methodBinding) {
+		return getSignatureForMethodKey(methodBinding.getKey());
+	}
+
 	/**
 	 * Returns the signature of the given method binding as a character array.
 	 *
@@ -166,6 +171,10 @@ public class SignatureUtils {
 	 */
 	public static char[] getSignatureChar(IMethodBinding methodBinding) {
 		return getSignatureForMethodKey(methodBinding.getKey()).toCharArray();
+	}
+
+	public static char[] getSignatureChar(IMethod method) {
+		return getSignatureForMethodKey(method.getKey()).toCharArray();
 	}
 
 	/**
@@ -185,6 +194,13 @@ public class SignatureUtils {
 		} else {
 			return removeName;
 		}
+	}
+
+	public static String stripTypeArgumentsFromKey(String key) {
+		if (key.indexOf(">;") < 0) {
+			return key;
+		}
+		return key.substring(0, key.lastIndexOf("<")) + "<>;";
 	}
 
 	/**

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
@@ -145,6 +145,7 @@ public class ExpectedTypes {
 			}
 			if (parent2 instanceof ClassInstanceCreation newObj && this.offset > newObj.getType().getStartPosition() + newObj.getType().getLength()) {
 				ITypeBinding binding = newObj.resolveTypeBinding();
+
 				if(binding != null) {
 					computeExpectedTypesForAllocationExpression(
 						binding,


### PR DESCRIPTION
Fixes some constructor completion tests that were failing, mostly related to the signature being slightly wrong.

Also suggests the first parameter for constructor invocations.

When the cursor is here (at the `|`):

```java
MyClass obj = new MyClass(|)
```

Then the appropriate parameter should be suggested (in addition to the constructor itself, as well as an anonymous constructor).

When the cursor is here:

```java
new MyClass().|
```

It should suggest appropriate fields and methods.