### PR TITLE
Fix resolving JavaElement for binary types/methods

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
@@ -112,6 +112,8 @@ import com.sun.tools.javac.util.Options;
  */
 public class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 
+	public static final String MOCK_NAME_FOR_CLASSES = "whatever_InvalidNameWE_HOP3_n00ne_will_Ever_use_in_real_file.java";
+	
 	private final class ForwardDiagnosticsAsDOMProblems implements DiagnosticListener<JavaFileObject> {
 		public final Map<JavaFileObject, CompilationUnit> filesToUnits;
 		private final JavacProblemConverter problemConverter;
@@ -711,7 +713,7 @@ public class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 					sourceUnitPath = Path.of(lastSegment);
 				}
 				if( sourceUnitPath == null )
-					sourceUnitPath = Path.of(new File("whatever.java").toURI());
+					sourceUnitPath = Path.of(new File(MOCK_NAME_FOR_CLASSES).toURI());
 			} else {
 				sourceUnitPath = Path.of(unitFile.toURI());
 			}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
@@ -159,6 +159,7 @@ import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.core.search.TypeNameMatch;
 import org.eclipse.jdt.core.search.TypeNameMatchRequestor;
+import org.eclipse.jdt.internal.SignatureUtils;
 import org.eclipse.jdt.internal.codeassist.impl.AssistOptions;
 import org.eclipse.jdt.internal.codeassist.impl.Keywords;
 import org.eclipse.jdt.internal.codeassist.impl.RestrictedIdentifiers;

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionUtil.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionUtil.java
@@ -31,6 +31,7 @@ import org.eclipse.jdt.core.dom.ExpressionMethodReference;
 import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
+import org.eclipse.jdt.internal.SignatureUtils;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SuperMethodReference;
 import org.eclipse.jdt.core.dom.TypeMethodReference;

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
@@ -36,6 +37,7 @@ import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.TypeParameter;
 import org.eclipse.jdt.core.dom.JavacBindingResolver.BindingKeyException;
+import org.eclipse.jdt.internal.SignatureUtils;
 import org.eclipse.jdt.internal.core.BinaryMethod;
 import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.Member;
@@ -280,6 +282,10 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 			typeParamsList.add(typeParams.get(i).getName().toString());
 		}
 
+		IMethod result = currentType.getMethod(getName(), Stream.of(getParameterTypes()).map(SignatureUtils::getSignature).toArray(String[]::new));
+		if (result.exists()) {
+			return result;
+		}
 		List<SingleVariableDeclaration> p = methodDeclaration.parameters();
 		String[] params = p.stream() //
 				.map(param -> {
@@ -289,10 +295,11 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 					}
 					return sig;
 				}).toArray(String[]::new);
-		IMethod result = currentType.getMethod(getName(), params);
-		if (currentType.isBinary() || result.exists()) {
+		result = currentType.getMethod(getName(), params);
+		if (result.exists()) {
 			return result;
 		}
+
 		IMethod[] methods = null;
 		try {
 			methods = currentType.getMethods();

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -55,6 +55,7 @@ import org.eclipse.jdt.core.dom.IPackageBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.JavacBindingResolver;
+import org.eclipse.jdt.core.dom.JavacCompilationUnitResolver;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.RecordDeclaration;
@@ -255,7 +256,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 				}
 			}
 			ITypeRoot typeRoot = null;
-			if (jfo != null) {
+			if (jfo != null && !jfo.getName().endsWith(JavacCompilationUnitResolver.MOCK_NAME_FOR_CLASSES)) {
 				var jfoFile = new File(jfo.getName());
 				var jfoPath = new Path(jfo.getName());
 				Stream<IFile> fileStream = jfoFile.isFile()	?
@@ -577,7 +578,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 					} catch (IllegalArgumentException e) {
 						// probably: uri is not a valid path
 					}
-					if (fileName != null && !fileName.startsWith(classSymbol.getSimpleName().toString())) {
+					if (fileName != null && !fileName.startsWith(classSymbol.getSimpleName().toString()) && !fileName.endsWith(JavacCompilationUnitResolver.MOCK_NAME_FOR_CLASSES)) {
 						// There are multiple top-level types in this file,
 						// inject 'FileName~' before the type name to show that this type came from `FileName.java`
 						// (eg. Lorg/eclipse/jdt/FileName~MyTopLevelType;)


### PR DESCRIPTION
* Special rules for when using a mock name for Javac (this could probably be improved by getting ASTParser to pass through the actual class name and resusing it)
* Use resolved types signatures from binding to retrieve method reference