### PR TITLE
[Search] Fix qualifiedSourceName

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMPatternLocator.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMPatternLocator.java
@@ -149,19 +149,13 @@ public class DOMPatternLocator extends PatternLocator {
 		}
 		ITypeBinding type = binding.isArray() ? binding.getComponentType() : binding;
 		String simpleName = type instanceof JavacTypeBinding ? ((JavacTypeBinding)type).getName(false) : binding.getName();
-		String qualifier = qualifiedSourceName(type.getDeclaringClass());
-		if( qualifier == null && type instanceof JavacTypeBinding jctb) {
-			String qualifiedName = jctb.getQualifiedName(false);
-			if( qualifiedName != null ) {
-				return qualifiedName;
-			}
-		}
 		if (type.isLocal()) {
-			return qualifier + ".1." + simpleName; //$NON-NLS-1$
+			return qualifiedSourceName(type.getDeclaringClass()) + ".1." + simpleName; //$NON-NLS-1$
 		} else if (type.isMember()) {
-			return qualifier + '.' + simpleName;
+			return qualifiedSourceName(type.getDeclaringClass()) + '.' + simpleName;
+		} else {
+			return simpleName;
 		}
-		return binding.getName();
 	}
 	protected int resolveLevelForType(char[] simpleNamePattern, char[] qualificationPattern, ITypeBinding binding) {
 		if( binding == null && simpleNamePattern == null && qualificationPattern == null )
@@ -212,7 +206,7 @@ public class DOMPatternLocator extends PatternLocator {
 		}
 		if (sourceName == null)
 			return IMPOSSIBLE_MATCH;
-		return resolveLevelForTypeSourceName(qualifiedPattern, sourceName, type);
+		return resolveLevelForTypeSourceName(qualifiedPattern, type.getQualifiedName().toCharArray(), type);
 	}
 	public static String qualifiedSourceName(ITypeBinding binding) {
 		if (binding == null) {

--- a/org.eclipse.jdt.core/.settings/.api_filters
+++ b/org.eclipse.jdt.core/.settings/.api_filters
@@ -6,6 +6,275 @@
                 <message_argument value="org.eclipse.jdt.core.dom.AST"/>
                 <message_argument value="JLS_Latest"/>
                 <message_argument value="23"/>
+    <resource path="dom/org/eclipse/jdt/core/dom/AST.java" type="org.eclipse.jdt.core.dom.AST">
+        <filter comment="javac branch has bigger version" id="1141899266">
+            <message_arguments>
+                <message_argument value="3.41"/>
+                <message_argument value="3.42"/>
+                <message_argument value="getAllVersions()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/AbstractTagElement.java" type="org.eclipse.jdt.core.dom.AbstractTagElement">
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="IDocElement"/>
+                <message_argument value="AbstractTagElement"/>
+            </message_arguments>
+        </filter>
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="AbstractTagElement"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/AbstractTextElement.java" type="org.eclipse.jdt.core.dom.AbstractTextElement">
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="IDocElement"/>
+                <message_argument value="AbstractTextElement"/>
+            </message_arguments>
+        </filter>
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="AbstractTextElement"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/Annotation.java" type="org.eclipse.jdt.core.dom.Annotation">
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="IExtendedModifier"/>
+                <message_argument value="Annotation"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/AnonymousClassDeclaration.java" type="org.eclipse.jdt.core.dom.AnonymousClassDeclaration">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="AnonymousClassDeclaration"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/BodyDeclaration.java" type="org.eclipse.jdt.core.dom.BodyDeclaration">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="BodyDeclaration"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/CatchClause.java" type="org.eclipse.jdt.core.dom.CatchClause">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="CatchClause"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/Comment.java" type="org.eclipse.jdt.core.dom.Comment">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="Comment"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/Dimension.java" type="org.eclipse.jdt.core.dom.Dimension">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="Dimension"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/Expression.java" type="org.eclipse.jdt.core.dom.Expression">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="Expression"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/ImportDeclaration.java" type="org.eclipse.jdt.core.dom.ImportDeclaration">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="ImportDeclaration"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/MemberRef.java" type="org.eclipse.jdt.core.dom.MemberRef">
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="IDocElement"/>
+                <message_argument value="MemberRef"/>
+            </message_arguments>
+        </filter>
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="MemberRef"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/MemberValuePair.java" type="org.eclipse.jdt.core.dom.MemberValuePair">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="MemberValuePair"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/MethodRef.java" type="org.eclipse.jdt.core.dom.MethodRef">
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="IDocElement"/>
+                <message_argument value="MethodRef"/>
+            </message_arguments>
+        </filter>
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="MethodRef"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/MethodRefParameter.java" type="org.eclipse.jdt.core.dom.MethodRefParameter">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="MethodRefParameter"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/Modifier.java" type="org.eclipse.jdt.core.dom.Modifier">
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="IExtendedModifier"/>
+                <message_argument value="Modifier"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/ModuleQualifiedName.java" type="org.eclipse.jdt.core.dom.ModuleQualifiedName">
+        <filter comment="Java 15 Merge" id="576778288">
+            <message_arguments>
+                <message_argument value="Name"/>
+                <message_argument value="ModuleQualifiedName"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/PackageDeclaration.java" type="org.eclipse.jdt.core.dom.PackageDeclaration">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="PackageDeclaration"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/QualifiedName.java" type="org.eclipse.jdt.core.dom.QualifiedName">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="Name"/>
+                <message_argument value="QualifiedName"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/SimpleName.java" type="org.eclipse.jdt.core.dom.SimpleName">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="Name"/>
+                <message_argument value="SimpleName"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/Statement.java" type="org.eclipse.jdt.core.dom.Statement">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="Statement"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/TagProperty.java" type="org.eclipse.jdt.core.dom.TagProperty">
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="IDocElement"/>
+                <message_argument value="TagProperty"/>
+            </message_arguments>
+        </filter>
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="TagProperty"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/Type.java" type="org.eclipse.jdt.core.dom.Type">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="Type"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/TypeParameter.java" type="org.eclipse.jdt.core.dom.TypeParameter">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="TypeParameter"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/VariableDeclaration.java" type="org.eclipse.jdt.core.dom.VariableDeclaration">
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="VariableDeclaration"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="model/org/eclipse/jdt/core/JavaCore.java" type="org.eclipse.jdt.core.JavaCore">
+        <filter comment="Javac branch has bigger version" id="1141899266">
+            <message_arguments>
+                <message_argument value="3.41"/>
+                <message_argument value="3.42"/>
+                <message_argument value="defaultRootModules(Iterable&lt;IPackageFragmentRoot&gt;, String)"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="model/org/eclipse/jdt/core/SourceRange.java" type="org.eclipse.jdt.core.SourceRange">
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="ISourceRange"/>
+                <message_argument value="SourceRange"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="model/org/eclipse/jdt/core/util/ByteCodeVisitorAdapter.java" type="org.eclipse.jdt.core.util.ByteCodeVisitorAdapter">
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="IBytecodeVisitor"/>
+                <message_argument value="ByteCodeVisitorAdapter"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="search/org/eclipse/jdt/core/search/IJavaSearchDelegate.java" type="org.eclipse.jdt.core.search.IJavaSearchDelegate">
+        <filter id="643846161">
+            <message_arguments>
+                <message_argument value="MatchLocator"/>
+                <message_argument value="IJavaSearchDelegate"/>
+                <message_argument value="locateMatches(MatchLocator, IJavaProject, PossibleMatch[], int, int)"/>
+            </message_arguments>
+        </filter>
+        <filter id="643846161">
+            <message_arguments>
+                <message_argument value="PossibleMatch"/>
+                <message_argument value="IJavaSearchDelegate"/>
+                <message_argument value="locateMatches(MatchLocator, IJavaProject, PossibleMatch[], int, int)"/>
             </message_arguments>
         </filter>
     </resource>


### PR DESCRIPTION
qualifiedSourceName is the qualified name (including parent types for nested/local types) but without including the package.

Fixes https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator/issues/1430

This PR is a rebase / clone of https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator/pull/1435 