### PR TITLE
Some more unparented comment completion fixes

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
@@ -1831,9 +1831,9 @@ public class DOMCompletionEngine implements ICompletionEngine {
 									} else {
 										// local types are suggested first
 										String currentPackage = ""; //$NON-NLS-1$
-										CompilationUnit cuNode = (CompilationUnit) DOMCompletionUtil.findParent(tagElement, new int[] { ASTNode.COMPILATION_UNIT });
-										if (cuNode.getPackage() != null) {
-											currentPackage = cuNode.getPackage().getName().toString();
+
+										if (this.unit.getPackage() != null) {
+											currentPackage = this.unit.getPackage().getName().toString();
 										}
 										final String finalizedCurrentPackage = currentPackage;
 
@@ -4520,12 +4520,12 @@ public class DOMCompletionEngine implements ICompletionEngine {
 		Javadoc javadoc = (Javadoc) DOMCompletionUtil.findParent(this.toComplete, new int[] { ASTNode.JAVADOC });
 		if (parentTypeDeclaration != null || javadoc != null) {
 			String fullTypeName = type.getFullyQualifiedName();
-			CompilationUnit cu = (CompilationUnit)DOMCompletionUtil.findParent(this.toComplete, new int [] { ASTNode.COMPILATION_UNIT });
-			boolean inImports = ((List<ImportDeclaration>)cu.imports()).stream().anyMatch(improt -> fullTypeName.equals(improt.getName().toString()));
+			boolean inImports = ((List<ImportDeclaration>)this.unit.imports()).stream().anyMatch(improt -> fullTypeName.equals(improt.getName().toString()));
+			boolean isInJavaLang = type.getFullyQualifiedName().startsWith("java.lang.") && !type.getFullyQualifiedName().substring("java.lang.".length()).contains(".");
 			IPackageBinding currentPackageBinding = parentTypeDeclaration == null ? null : parentTypeDeclaration.resolveBinding().getPackage();
 			if (packageFrag != null && (currentPackageBinding == null
 					|| (!packageFrag.getElementName().equals(currentPackageBinding.getName())
-							&& !packageFrag.getElementName().equals("java.lang"))) && !inImports) { //$NON-NLS-1$
+							&& !packageFrag.getElementName().equals("java.lang"))) && !inImports && !isInJavaLang) { //$NON-NLS-1$
 				completion.insert(0, '.');
 				completion.insert(0, packageFrag.getElementName());
 			}


### PR DESCRIPTION
- Improve selection algorithm of unparented comments in `DOMCompletionContext`
- When completing a type in a Javadoc, do not fully qualify types from `java.lang`

Fixes 8