### PR TITLE
Refactor "find parent type binding"

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionUtil.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionUtil.java
@@ -31,10 +31,10 @@ import org.eclipse.jdt.core.dom.ExpressionMethodReference;
 import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
-import org.eclipse.jdt.internal.SignatureUtils;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SuperMethodReference;
 import org.eclipse.jdt.core.dom.TypeMethodReference;
+import org.eclipse.jdt.internal.SignatureUtils;
 
 public class DOMCompletionUtil {
 


### PR DESCRIPTION
Make an instance variable for storing `DOMCompletionContext`. Then, provide a method for lazy loading the binding of the current type in `DOMCompletionContext`.

As well:
- Delete some unused variables
- Fix the broken accessibility check for IType