### PR TITLE
Move true/false binding finder into utils class

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionContext.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionContext.java
@@ -137,7 +137,7 @@ class DOMCompletionContext extends CompletionContext {
 			this.node = NodeFinder.perform(domUnit, adjustedOffset, length);
 		}
 		this.expectedTypes = new ExpectedTypes(assistOptions, this.node, offset);
-		this.inJavadoc = DOMCompletionUtil.findParent(this.node, new int[] { ASTNode.JAVADOC }) != null;
+		this.inJavadoc = DOMCompletionUtils.findParent(this.node, new int[] { ASTNode.JAVADOC }) != null;
 		this.token = tokenBefore(this.textContent).toCharArray();
 		this.bindingsAcquirer = bindings::all;
 		this.isJustAfterStringLiteral = this.node instanceof StringLiteral && this.node.getLength() > 1 && this.offset >= this.node.getStartPosition() + this.node.getLength() && textContent.charAt(this.offset - 1) == '"';
@@ -458,7 +458,7 @@ class DOMCompletionContext extends CompletionContext {
 	 */
 	public ITypeBinding getCurrentTypeBinding() {
 		if (currentTypeBinding == null) {
-			ASTNode parentType = DOMCompletionUtil.findParent(node, new int[] {
+			ASTNode parentType = DOMCompletionUtils.findParent(node, new int[] {
 					ASTNode.TYPE_DECLARATION, ASTNode.ENUM_DECLARATION, ASTNode.RECORD_DECLARATION,
 					ASTNode.ANNOTATION_TYPE_DECLARATION, ASTNode.ANONYMOUS_CLASS_DECLARATION
 			});

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngineJavadocUtil.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngineJavadocUtil.java
@@ -159,14 +159,14 @@ class DOMCompletionEngineJavadocUtil {
 	}
 
 	private static List<char[]> tagsForNode(List<char[]> tagsForVersion, TagElement tagNode, ASTNode nodeSearchNode) {
-		boolean isField = DOMCompletionUtil.findParent(tagNode, new int[]{ ASTNode.FIELD_DECLARATION }) != null;
+		boolean isField = DOMCompletionUtils.findParent(tagNode, new int[]{ ASTNode.FIELD_DECLARATION }) != null;
 		if (isField) {
 			return tagsForVersion.stream() //
 					.filter(tag -> FIELD_TAGS_SET.contains(tag)) //
 					.toList();
 		}
 
-		ASTNode astNode = DOMCompletionUtil.findParent(tagNode, new int[] {
+		ASTNode astNode = DOMCompletionUtils.findParent(tagNode, new int[] {
 				ASTNode.METHOD_DECLARATION,
 				ASTNode.TYPE_DECLARATION,
 				ASTNode.ENUM_DECLARATION,
@@ -194,16 +194,16 @@ class DOMCompletionEngineJavadocUtil {
 					.toList();
 		}
 
-		boolean isPackage = DOMCompletionUtil.findParent(tagNode, new int[] {ASTNode.PACKAGE_DECLARATION}) != null;
+		boolean isPackage = DOMCompletionUtils.findParent(tagNode, new int[] {ASTNode.PACKAGE_DECLARATION}) != null;
 		if (isPackage) {
 			return tagsForVersion.stream() //
 					.filter(tag -> PACKAGE_TAGS_SET.contains(tag)) //
 					.toList();
 		}
 
-		boolean isUnparented = DOMCompletionUtil.findParent(tagNode, new int[] {ASTNode.JAVADOC}) instanceof Javadoc javadoc && javadoc.getParent() == null;
+		boolean isUnparented = DOMCompletionUtils.findParent(tagNode, new int[] {ASTNode.JAVADOC}) instanceof Javadoc javadoc && javadoc.getParent() == null;
 		if (isUnparented) {
-			boolean onlyClassTags = DOMCompletionUtil.findParentTypeDeclaration(nodeSearchNode) == null;
+			boolean onlyClassTags = DOMCompletionUtils.findParentTypeDeclaration(nodeSearchNode) == null;
 			return tagsForVersion.stream() //
 					.filter(tag -> !onlyClassTags || CLASS_TAGS_SET.contains(tag)) //
 					.toList();

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
@@ -237,7 +237,7 @@ public class ExpectedTypes {
 			}
 			if (parent2 instanceof TagElement te) {
 				if (TagElement.TAG_THROWS.equals(te.getTagName())) {
-					Javadoc javadoc = (Javadoc)DOMCompletionUtil.findParent(te, new int[] { ASTNode.JAVADOC });
+					Javadoc javadoc = (Javadoc)DOMCompletionUtils.findParent(te, new int[] { ASTNode.JAVADOC });
 					if (javadoc.getParent() instanceof MethodDeclaration methodDecl) {
 						this.expectedTypes.addAll(((List<Type>)methodDecl.thrownExceptionTypes()).stream().map(Type::resolveBinding).toList());
 					}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/RelevanceUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/RelevanceUtils.java
@@ -154,7 +154,7 @@ class RelevanceUtils {
 			}
 			for (ITypeBinding expectedType : expectedTypes.getExpectedTypes()) {
 				if(expectedTypes.allowsSubtypes()
-						&& DOMCompletionUtil.findInSupers(proposalType, expectedType.getKey(), workingCopyOwner, typeHierarchyCache)) {
+						&& DOMCompletionUtils.findInSupers(proposalType, expectedType.getKey(), workingCopyOwner, typeHierarchyCache)) {
 					if (expectedType.getKey().equals(proposalType.getKey())) {
 						return RelevanceConstants.R_EXACT_EXPECTED_TYPE;
 						// ??? I'm just guessing on the default packages name here, it might be the empty string
@@ -164,7 +164,7 @@ class RelevanceUtils {
 					relevance = RelevanceConstants.R_EXPECTED_TYPE;
 
 				}
-				if(expectedTypes.allowsSupertypes() && DOMCompletionUtil.findInSupers(expectedType, proposalType.getKey())) {
+				if(expectedTypes.allowsSupertypes() && DOMCompletionUtils.findInSupers(expectedType, proposalType.getKey())) {
 					if (expectedType.getKey().equals(proposalType.getKey())) {
 						return RelevanceConstants.R_EXACT_EXPECTED_TYPE;
 					}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMConstructorLocator.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMConstructorLocator.java
@@ -23,7 +23,7 @@ import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
 import org.eclipse.jdt.core.dom.Type;
-import org.eclipse.jdt.internal.codeassist.DOMCompletionUtil;
+import org.eclipse.jdt.internal.codeassist.DOMCompletionUtils;
 import org.eclipse.jdt.internal.compiler.ast.Argument;
 import org.eclipse.jdt.internal.compiler.ast.ConstructorDeclaration;
 import org.eclipse.jdt.internal.core.search.DOMASTNodeUtils;
@@ -80,7 +80,7 @@ public class DOMConstructorLocator extends DOMPatternLocator {
 				return toResponse(IMPOSSIBLE_MATCH);
 			}
 			if (this.locator.pattern.declaringSimpleName != null) {
-				if (!this.matchesName(this.locator.pattern.declaringSimpleName, DOMCompletionUtil.findParentTypeDeclaration(node).getName().getIdentifier().toCharArray())) {
+				if (!this.matchesName(this.locator.pattern.declaringSimpleName, DOMCompletionUtils.findParentTypeDeclaration(node).getName().getIdentifier().toCharArray())) {
 					return toResponse(IMPOSSIBLE_MATCH);
 				}
 			}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacVariableBinding.java
@@ -39,7 +39,7 @@ import org.eclipse.jdt.core.dom.VariableDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationExpression;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
-import org.eclipse.jdt.internal.codeassist.DOMCompletionUtil;
+import org.eclipse.jdt.internal.codeassist.DOMCompletionUtils;
 import org.eclipse.jdt.internal.core.BinaryMember;
 import org.eclipse.jdt.internal.core.DOMToModelPopulator;
 import org.eclipse.jdt.internal.core.JavaElement;
@@ -237,7 +237,7 @@ public abstract class JavacVariableBinding implements IVariableBinding {
 
 	private boolean isUnique() {
 		ASTNode variable = this.resolver.findDeclaringNode(this);
-		MethodDeclaration parentMethod = (MethodDeclaration)DOMCompletionUtil.findParent(variable, new int[] { ASTNode.METHOD_DECLARATION });
+		MethodDeclaration parentMethod = (MethodDeclaration)DOMCompletionUtils.findParent(variable, new int[] { ASTNode.METHOD_DECLARATION });
 		if (parentMethod == null) {
 			return true;
 		}


### PR DESCRIPTION
The true/false binding finder doesn't rely on much completion context and can be extracted into a static helper method.

- Move DOMCompletionUtil to DOMCompletionUtil*s*
  - This was a joke naming because there was initially only one method in the class, I should have just stuck with the convential name to begin with.