### PR TITLE
Do not take return type into account when matching methods

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMMethodLocator.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMMethodLocator.java
@@ -229,9 +229,12 @@ public class DOMMethodLocator extends DOMPatternLocator {
 		if (level == IMPOSSIBLE_MATCH)
 			return level;
 
-		level = resolveLevelForType(this.locator.pattern.returnSimpleName, this.locator.pattern.returnQualification, method.getReturnType());
-		if (level == IMPOSSIBLE_MATCH)
-			return level;
+		if (this.pattern.declaringSimpleName == null) {
+			// look at return type only if declaring type is not specified
+			level = resolveLevelForType(this.locator.pattern.returnSimpleName, this.locator.pattern.returnQualification, method.getReturnType());
+			if (level == IMPOSSIBLE_MATCH)
+				return level;
+		}
 
 
 		level = matchMethodParametersTypes(node, method, skipImpossibleArg, level);


### PR DESCRIPTION
When matching known methods (which have a "declaringSimpleName", then we don't need to care about the return type to match the overridden methods.