### PR TITLE
Expected types for yield statement

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/ExpectedTypes.java
@@ -60,6 +60,7 @@ import org.eclipse.jdt.core.dom.TypeParameter;
 import org.eclipse.jdt.core.dom.VariableDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.WhileStatement;
+import org.eclipse.jdt.core.dom.YieldStatement;
 import org.eclipse.jdt.internal.codeassist.impl.AssistOptions;
 
 /**
@@ -131,6 +132,9 @@ public class ExpectedTypes {
 			}
 			if (parent2 instanceof ReturnStatement) {
 				break;
+			}
+			if (parent2 instanceof YieldStatement) {
+				parent2 = DOMCompletionUtils.findParent(parent2, new int[] {ASTNode.SWITCH_EXPRESSION});
 			}
 			if (parent2 instanceof Block) {
 				break;

--- a/org.eclipse.jdt.core.tests.javac/src/org/eclipse/jdt/core/tests/javac/JavacSpecificCompletionTests.java
+++ b/org.eclipse.jdt.core.tests.javac/src/org/eclipse/jdt/core/tests/javac/JavacSpecificCompletionTests.java
@@ -552,5 +552,44 @@ public class JavacSpecificCompletionTests {
 		Assert.assertTrue(requestor.getResults().contains(expectedContent));
 	}
 
+	@Test
+	public void testCompleteYieldStatement() throws Exception {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("HelloWorld.java",
+			"""
+			public class HelloWorld  {
+				public static enum Color { RED, GREEN, BLUE; }
+				public static class NaturalGas {}
+				public static class NaturalHistory {}
+				void m() {
+					Color c = null;
+					int naturalize = 2;
+					String naturalist = "sandiwch";
+					int i = switch (c) {
+						case BLUE: {
+							if (1<2) {
+								yield ;
+							}
+						}
+						default -> 1;
+					};
+				}
+			}
+			""");
+
+		// add the replace range to the results
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(false, false, true);
+
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "yield ";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		IProgressMonitor monitor = new NullProgressMonitor();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, WC_OWNER, monitor);
+		Assert.assertTrue(requestor.getReversedResults().startsWith("""
+				hashCode[METHOD_REF]{hashCode(), Ljava.lang.Object;, ()I, hashCode, [301, 301], 82}
+				naturalize[LOCAL_VARIABLE_REF]{naturalize, null, I, naturalize, [301, 301], 82}
+				"""));
+	}
+
 
 }


### PR DESCRIPTION
This makes the result consistent with what's done with `return`, but inconsistent with what's done upstream.

- [x] tests