### PR TITLE
Fix computation of mustResolve

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/PatternLocatorVisitor.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/PatternLocatorVisitor.java
@@ -104,8 +104,8 @@ class PatternLocatorVisitor extends ASTVisitor {
 			T node,
 			BiFunction<T, DOMPatternLocator, LocatorResponse> levelFunc,
 			Function<ASTNode, IBinding> bindingFunc) {
-		boolean mustResolve = (this.nodeSet.mustResolve() || this.locator.patternLocator.isMustResolve());
 		LocatorResponse resp = levelFunc.apply(node, this.domPatternLocator);
+		boolean mustResolve = (this.nodeSet.mustResolve() || this.locator.patternLocator.isMustResolve());
 		boolean nodeReplaced = resp.replacementNodeFound();
 		ASTNode n2 = nodeReplaced ? resp.replacement() : node;
 		n2 = n2 == null ? node : n2;

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMMethodLocator.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMMethodLocator.java
@@ -237,7 +237,7 @@ public class DOMMethodLocator extends DOMPatternLocator {
 		if (level == IMPOSSIBLE_MATCH)
 			return level;
 
-		if (this.pattern.declaringSimpleName == null) {
+		if (this.pattern.declaringSimpleName == null && this.locator.pattern.returnSimpleName != null) {
 			// look at return type only if declaring type is not specified
 			level = resolveLevelForType(this.locator.pattern.returnSimpleName, this.locator.pattern.returnQualification, method.getReturnType());
 			if (level == IMPOSSIBLE_MATCH)
@@ -454,20 +454,15 @@ public class DOMMethodLocator extends DOMPatternLocator {
 	}
 
 	protected int matchMethodBindingReturn(IMethodBinding binding) {
-		int level = ACCURATE_MATCH;
 		// look at return type only if declaring type is not specified
 		if (this.locator.pattern.declaringSimpleName == null) {
 			// TODO (frederic) use this call to refine accuracy on return type
 			// int newLevel = resolveLevelForType(this.locator.pattern.returnSimpleName, this.locator.pattern.returnQualification, this.locator.pattern.returnTypeArguments, 0, method.returnType);
-			int newLevel = resolveLevelForType(this.locator.pattern.returnSimpleName, this.locator.pattern.returnQualification,
-					binding.getReturnType());
-			if (level > newLevel) {
-				if (newLevel == IMPOSSIBLE_MATCH)
-					return IMPOSSIBLE_MATCH;
-				level = newLevel; // can only be downgraded
-			}
+			if (resolveLevelForType(this.locator.pattern.returnSimpleName, this.locator.pattern.returnQualification,
+					binding.getReturnType()) == IMPOSSIBLE_MATCH)
+				return IMPOSSIBLE_MATCH;
 		}
-		return level;
+		return ACCURATE_MATCH;
 	}
 
 	private int matchMethodParametersTypes(ASTNode node, IMethodBinding method, boolean skipImpossibleArg, int level) {

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMPatternLocator.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMPatternLocator.java
@@ -164,6 +164,9 @@ public class DOMPatternLocator extends PatternLocator {
 
 	protected int resolveLevelForTypeFQN(char[] simpleNamePattern, char[] qualificationPattern, ITypeBinding binding, IImportDiscovery discovery) {
 		int level = 0;
+		if (simpleNamePattern == null) {
+			return ACCURATE_MATCH;
+		}
 		if (qualificationPattern == null && simpleNamePattern != null) {
 			level = resolveLevelForTypeSourceName(simpleNamePattern, (binding.isArray() ? binding : binding.getErasure()).getName().toCharArray(), binding);
 		}


### PR DESCRIPTION
particular locators can force resolution, read the mustResolve state after processing the locators

+ make any string match null/ignored name in pattern