### PR TITLE
Fix bad method signature

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/SignatureUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/SignatureUtils.java
@@ -189,11 +189,14 @@ public class SignatureUtils {
 				.replace("<+Ljava.lang.Object;>", "<*>");
 		String removeName = fullKey.substring(fullKey.indexOf('('));
 		int firstException = removeName.indexOf('|');
+		String exceptionRemoved;
 		if (firstException > 0) {
-			return removeName.substring(0, firstException);
+			exceptionRemoved =  removeName.substring(0, firstException);
 		} else {
-			return removeName;
+			exceptionRemoved = removeName;
 		}
+		// strip out the weird information the keys need to differentiate themselves
+		return exceptionRemoved.replaceAll("!L[^;]+;\\{[0-9]+\\}(\\+L[^;]+;)[0-9]+;", "$1");
 	}
 
 	public static String stripTypeArgumentsFromKey(String key) {

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/RelevanceUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/RelevanceUtils.java
@@ -109,6 +109,8 @@ class RelevanceUtils {
 
 					if(Objects.equals(expectedType.getQualifiedName(), proposalType.getQualifiedName())) {
 						return RelevanceConstants.R_EXACT_EXPECTED_TYPE;
+					} else if (expectedType.isRawType() && Objects.equals(expectedType.getErasure().getQualifiedName(), proposalType.getErasure().getQualifiedName())) {
+						return RelevanceConstants.R_EXACT_EXPECTED_TYPE;
 					} else if (proposalType.getPackage() != null && proposalType.getPackage().isUnnamed()) {
 						return RelevanceConstants.R_PACKAGE_EXPECTED_TYPE;
 					}

--- a/org.eclipse.jdt.core.tests.javac/src/org/eclipse/jdt/core/tests/javac/JavacSpecificCompletionTests.java
+++ b/org.eclipse.jdt.core.tests.javac/src/org/eclipse/jdt/core/tests/javac/JavacSpecificCompletionTests.java
@@ -635,4 +635,32 @@ public class JavacSpecificCompletionTests {
 				hashCode[METHOD_REF]{hashCode(), Ljava.lang.Object;, ()I, hashCode, [201, 201], 79}""", requestor.getResults());
 	}
 
+	@Test
+	public void testCompleteMethodWithWildcardReturnType() throws Exception {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("HelloWorld.java",
+			"""
+			import java.util.List;
+
+			public class HelloWorld  {
+				public List<? extends String> getMyList() {
+					return List.of();
+				}
+				void m() {
+					List myList = getMyLi
+				}
+			}
+			""");
+
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(false, false, true);
+
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "getMyLi";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		IProgressMonitor monitor = new NullProgressMonitor();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, WC_OWNER, monitor);
+		assertEquals("""
+				getMyList[METHOD_REF]{getMyList(), LHelloWorld;, ()Ljava.util.List<+Ljava.lang.String;>;, getMyList, [147, 154], 82}""", requestor.getResults());
+	}
+
 }


### PR DESCRIPTION
Uses a regex to strip some extra information that's present in keys but not signatures.

Includes a new test case to cover this behaviour, since there is no existing test for this.

Includes an unrelated fix (relevance number when a raw type is expected) to get the new test case passing.

Fixes #1414