### PR TITLE
Fix completion and relevance for super field

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionEngine.java
@@ -339,9 +339,7 @@ public class DOMCompletionEngine implements ICompletionEngine {
 				.filter(binding -> !assistOptions.checkDeprecation || !isDeprecated(binding.getJavaElement()))
 				.flatMap(binding -> {
 					if (binding instanceof IMethodBinding methodBinding
-							&& !(DOMCompletionEngine.this.toComplete.getParent() instanceof QualifiedName)
-							&& !(DOMCompletionEngine.this.toComplete.getParent() instanceof MethodInvocation)
-							&& !(DOMCompletionEngine.this.toComplete.getParent() instanceof FieldAccess)) {
+							&& !DOMCompletionUtils.isInQualifiedName(DOMCompletionEngine.this.toComplete)) {
 						// Handle referencing methods from parent classes using ClassName.this.methodName()
 						// Note that the completion text is correct,
 						// but due to bugs in jdt.ui this completion doesn't work in practice

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionUtils.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.PrefixExpression;
 import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
 import org.eclipse.jdt.core.dom.SuperMethodReference;
 import org.eclipse.jdt.core.dom.TypeMethodReference;
 import org.eclipse.jdt.core.dom.TypePattern;
@@ -214,10 +215,12 @@ public class DOMCompletionUtils {
 				FieldAccess.NAME_PROPERTY,
 				ExpressionMethodReference.NAME_PROPERTY,
 				TypeMethodReference.NAME_PROPERTY,
-				SuperMethodReference.NAME_PROPERTY).contains(node.getLocationInParent())
+				SuperMethodReference.NAME_PROPERTY,
+				SuperFieldAccess.NAME_PROPERTY).contains(node.getLocationInParent())
 				|| node instanceof FieldAccess
 				|| node instanceof QualifiedName
 				|| node instanceof SuperMethodReference
+				|| node instanceof SuperFieldAccess
 				|| node instanceof TypeMethodReference;
 	}
 


### PR DESCRIPTION
- Do not suggest methods from enclosing types after `super.|`
- These completions should count as NON_STATIC
- These completion should not count as either QUALIFIED or UNQUALIFIED

Fixes 1 case