### PR TITLE
Assorted completion bug fixes

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -1270,6 +1270,11 @@ class JavacConverter {
 					// when there are syntax errors where the statement is not completed.
 					qualifiedName = this.ast.newSimpleName(FAKE_IDENTIFIER);
 					qualifiedName.setFlags(ASTNode.RECOVERED);
+				} else {
+					int qualifiedOffset = this.rawText.indexOf(qualifiedName.toString(), qualifierName.getStartPosition() + qualifierName.getLength() + 1);
+					if (qualifiedOffset != -1) {
+						qualifiedName.setSourceRange(qualifiedOffset, qualifiedName.toString().length());
+					}
 				}
 				QualifiedName res = this.ast.newQualifiedName(qualifierName, qualifiedName);
 				commonSettings(res, javac);

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/codeassist/DOMCompletionUtils.java
@@ -28,6 +28,8 @@ import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
+import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ExpressionMethodReference;
 import org.eclipse.jdt.core.dom.FieldAccess;
@@ -314,6 +316,20 @@ public class DOMCompletionUtils {
 			});
 			return new TrueFalseCasts(castedTypes, Collections.emptyList());
 		}
+	}
+
+	public static List<ITypeBinding> getParentTypeDeclarations(ASTNode cursor) {
+		List<ITypeBinding> parentTypeBinding = new ArrayList<>();
+		while (DOMCompletionUtils.findParentTypeDeclaration(cursor) != null) {
+			ASTNode parentTypeDeclaration = DOMCompletionUtils.findParentTypeDeclaration(cursor);
+			if (parentTypeDeclaration instanceof AbstractTypeDeclaration typeDecl) {
+				parentTypeBinding.add(typeDecl.resolveBinding());
+			} else {
+				parentTypeBinding.add(((AnonymousClassDeclaration)parentTypeDeclaration).resolveBinding());
+			}
+			cursor = parentTypeDeclaration.getParent();
+		}
+		return parentTypeBinding;
 	}
 
 }


### PR DESCRIPTION
- Don't complete enum constant declarations
- Better handling of completion of qualified `super` and `this` (take into account if you're in an interface)
- Improve `JavacConverter` to handle "field access" split across two lines as in `CompletionTests.testBug573632` (signatures don't match properly so it's not passing)

Should fix 4 and improve many more