### PR TITLE
Don't convert module when using Java 8

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacBindingResolver.java
@@ -1635,8 +1635,7 @@ public class JavacBindingResolver extends BindingResolver {
 		resolve();
 		JCTree javacElement = this.converter.domToJavac.get(module);
 		if( javacElement instanceof JCModuleDecl jcmd) {
-			Object o = jcmd.sym.type;
-			if( o instanceof ModuleType mt ) {
+			if (jcmd.sym != null && jcmd.sym.type instanceof ModuleType mt) {
 				return this.bindings.getModuleBinding(mt);
 			}
 		}

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -191,7 +191,7 @@ class JavacConverter {
 				res.setPackage(possible);
 			}
 		}
-		if (javacCompilationUnit.getModule() != null) {
+		if (javacCompilationUnit.getModule() != null && this.ast.apiLevel >= AST.JLS9_INTERNAL) {
 			res.setModule(convert(javacCompilationUnit.getModuleDecl()));
 		}
 		javacCompilationUnit.getImports().stream().filter(imp -> imp instanceof JCImport).map(jc -> convert((JCImport)jc)).forEach(res.imports()::add);

--- a/org.eclipse.jdt.core.tests.javac/src/org/eclipse/jdt/core/tests/javac/JavacSpecificConverterTests.java
+++ b/org.eclipse.jdt.core.tests.javac/src/org/eclipse/jdt/core/tests/javac/JavacSpecificConverterTests.java
@@ -11,14 +11,18 @@
 package org.eclipse.jdt.core.tests.javac;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
 import org.eclipse.jdt.core.dom.Javadoc;
+import org.eclipse.jdt.core.dom.ModuleDeclaration;
 import org.eclipse.jdt.core.dom.TagElement;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.junit.Test;
@@ -49,5 +53,24 @@ public class JavacSpecificConverterTests {
 		Javadoc javadoc = fieldDecl.getJavadoc();
 		TagElement elt = (TagElement)javadoc.tags().get(0);
 		assertEquals(elt.getTagName(), TagElement.TAG_SERIAL);
+	}
+
+	@Test
+	public void testModuleConversionUnderJava8() throws Exception {
+		ASTParser parser = ASTParser.newParser(AST.JLS8);
+		parser.setSource("""
+			module org.example.util {
+				requires java.base;
+			}
+			""".toCharArray());
+		ASTNode node = parser.createAST(new NullProgressMonitor());
+		assertTrue(node instanceof CompilationUnit);
+		node.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(ModuleDeclaration node) {
+				fail("expected no module declaration");
+				return false;
+			}
+		});
 	}
 }


### PR DESCRIPTION
There are other issues that arise when having a `module-info.java` in a Java 8 project, but this makes sure that we at least don't try to convert the AST nodes, which prevents an exception.

Fixes #293