### PR TITLE
Better match reference to record components

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMLocalVariableLocator.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMLocalVariableLocator.java
@@ -82,7 +82,10 @@ public class DOMLocalVariableLocator extends DOMPatternLocator {
 		}
 		Object bindingElement = binding.getJavaElement();
 		LocalVariable localVar = getLocalVariable();
-		if (Objects.equals(bindingElement, localVar)) {
+		if (localVar != null &&
+			bindingElement instanceof LocalVariable resolvedVarElement &&
+			Objects.equals(localVar.getElementName(), resolvedVarElement.getElementName()) &&
+			localVar.nameStart == resolvedVarElement.nameStart) {
 			// We need to know if this is a reference request or a declaration request
 			if (this.locator.pattern.findReferences) {
 				return new LocatorResponse(ACCURATE_MATCH, false, node, false, false);


### PR DESCRIPTION
Record components are often modeled as ILocalVariable, which might use different parent in a case or another. Instead of strictly checking for equal model element, we check that they are equivalent (name and position)