### PR TITLE
Revert "Ignore whitespaces for EnumConstantDecl with anonymous class"

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/DOMASTNodeUtils.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/DOMASTNodeUtils.java
@@ -297,14 +297,4 @@ public class DOMASTNodeUtils {
 		}
 		return false;
 	}
-
-	public static CompilationUnit enclosingUnit(ASTNode node) {
-		while (node != null) {
-			if (node instanceof CompilationUnit cu) {
-				return cu;
-			}
-			node = node.getParent();
-		}
-		return null;
-	}
 }

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMJavaSearchDelegate.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/core/search/matching/DOMJavaSearchDelegate.java
@@ -422,17 +422,6 @@ public class DOMJavaSearchDelegate implements IJavaSearchDelegate {
 			int len = enumConstantDeclaration.getLength();
 			if (enumConstantDeclaration.getAnonymousClassDeclaration() != null) {
 				len = enumConstantDeclaration.getAnonymousClassDeclaration().getStartPosition() - start;
-				// ignore trailing whitespaces
-				if (DOMASTNodeUtils.enclosingUnit(node).getJavaElement() instanceof ICompilationUnit unit) {
-					try {
-						IBuffer buffer = unit.getBuffer();
-						while (buffer != null && len > 0 && Character.isWhitespace(buffer.getChar(start + len - 1))) {
-							len--;
-						}
-					} catch (JavaModelException ex) {
-						ILog.get().warn(ex.getMessage(), ex);
-					}
-				}
 			}
 			return new FieldDeclarationMatch(DOMASTNodeUtils.getDeclaringJavaElement(node), accuracy, start, len,
 					getParticipant(locator), resource);


### PR DESCRIPTION
Reverts eclipse-jdtls/eclipse-jdt-core-incubator#1692 as it seems to cause memory leaks