### PR TITLE
JavacTypeBinding.getDeclaredMethods() order

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacTypeBinding.java
@@ -860,7 +860,7 @@ public abstract class JavacTypeBinding implements ITypeBinding {
 		if (isFromSource()) {
 			methods = methods.sorted(Comparator.comparingInt(member -> {
 				ASTNode node = this.resolver.findDeclaringNode(member);
-				return node == null ? Integer.MAX_VALUE : node.getStartPosition();
+				return node == null ? Integer.MIN_VALUE : node.getStartPosition();
 			}));
 		} else {
 			// JDT's class reader keeps the order for fields and methods


### PR DESCRIPTION
Put implicit methods (eg constructors) first