### PR TITLE
Fix StackOverflow in parameterized method binding key

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
@@ -474,7 +474,7 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 			if (methodType instanceof MethodType && !methodType.getTypeVariables().isEmpty()) { // parameterized
 				builder.append('<');
 				for (var typeParam : methodType.getTypeVariables()) {
-					JavacTypeBinding.getKey(builder, (Type)typeParam, false, true, useSlashes, resolver);
+					builder.append(JavacTypeVariableBinding.getTypeVariableKey((TypeVariableSymbol)typeParam.asElement(), resolver));
 				}
 				builder.append('>');
 			} else if (methodType instanceof ForAll && !methodType.getTypeVariables().isEmpty()) { // generic


### PR DESCRIPTION
Changes `JavaSearchBugs9Tests.testGH902_whenTypeReferenceIsUnknownButQualified_expectToBeFound` and three other similar tests from an error to a failure.

- Fix recovered type binding implementations (some use recursion with no base case, some fail to consider that there's no type or symbol)
- Fix typevar tries to use method key in its key but method key uses typevar key
  - There's an existing to get around this, but it wasn't being used for some reason