### PR TITLE
Ignore "generated" types

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacConverter.java
@@ -1074,7 +1074,9 @@ class JavacConverter {
 	private VariableDeclaration convertVariableDeclarationForLambda(JCVariableDecl javac) {
 		if(javac.getType() == null && javac.getStartPosition() == javac.getPreferredPosition() /* check no "var" */) {
 			return createVariableDeclarationFragment(javac);
-		} else if (javac.getType() != null && javac.getType().getPreferredPosition() == Position.NOPOS) { // "virtual" node added for analysis, not part of AST
+		} else if (javac.getType() != null &&
+				(javac.getType().getPreferredPosition() == Position.NOPOS
+				|| javac.getType().getEndPosition(javacCompilationUnit.endPositions) == Position.NOPOS)) { // "virtual" node added for analysis, not part of AST
 			return createVariableDeclarationFragment(javac);
 		} else {
 			return convertVariableDeclaration(javac);


### PR DESCRIPTION
Newer Java version seems to change the position of "generated" type for lambdas. Improve the condition to better cover it.

Fixes https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator/issues/1863