### PR TITLE
Use existing model for listCompilationUnitsWithMultipleTopLevelClasses

### DIFF
--- a/org.eclipse.jdt.core.tests.javac/src/org/eclipse/jdt/core/tests/javac/RegressionTests.java
+++ b/org.eclipse.jdt.core.tests.javac/src/org/eclipse/jdt/core/tests/javac/RegressionTests.java
@@ -193,6 +193,7 @@ public class RegressionTests {
 		try (var _ = withoutAutoBuild()) {
 			IProject proj = importProject("projects/secondaryType");
 			IJavaProject javaProject = JavaCore.create(proj);
+			waitForBackgroundJobs();
 			var unit = (ICompilationUnit)javaProject.findElement(Path.fromOSString("sec/Consumer.java"));
 			ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
 			parser.setSource(unit);


### PR DESCRIPTION
No need to compute this info as model manager already has it.